### PR TITLE
[microsoft-entra] Fix call on create users method

### DIFF
--- a/microsoft-entra/src/openbas_microsoft_entra.py
+++ b/microsoft-entra/src/openbas_microsoft_entra.py
@@ -114,7 +114,7 @@ class OpenBASMicrosoftEntra:
             for i in range(len(groups.value)):
                 team = {"team_name": groups.value[i].display_name}
                 openbas_team = self.helper.api.team.upsert(team)
-                await self.create_users(groups.value[i].id, openbas_team)
+                await self.create_users(graph_client, groups.value[i].id, openbas_team)
         # iterate over result batches > 100 rows
         while groups is not None and groups.odata_next_link is not None:
             groups = await graph_client.groups.with_url(groups.odata_next_link)


### PR DESCRIPTION
Error

{"timestamp": "2024-09-18T12:15:10.203153Z", "level": "ERROR", "name": "Microsoft Entra", "message": "Error collecting: OpenBASMicrosoftEntra.create_users() missing 1 required positional argument: 'openbas_team'", "exc_info": "Traceback (most recent call last):\n  File \"C:\\Users\\RomualdLemesle\\IdeaProjects\\openbas-python\\client-python\\pyobas\\helpers.py\", line 376, in schedule\n    message_callback()\n  File \"C:\\Users\\RomualdLemesle\\IdeaProjects\\openbas-python\\collectors-python\\microsoft-entra\\src\\openbas_microsoft_entra.py\", line 141, in _process_message\n    loop.run_until_complete(self.create_groups(graph_client))\n  File \"C:\\Dev\\Tools\\Python\\Lib\\asyncio\\base_events.py\", line 687, in run_until_complete\n    return future.result()\n           ^^^^^^^^^^^^^^^\n  File \"C:\\Users\\RomualdLemesle\\IdeaProjects\\openbas-python\\collectors-python\\microsoft-entra\\src\\openbas_microsoft_entra.py\", line 117, in create_groups\n    await self.create_users(groups.value[i].id, openbas_team)\n          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\nTypeError: OpenBASMicrosoftEntra.create_users() missing 1 required positional argument: 'openbas_team'", "taskName": null}

