### PR TITLE
[microsoft-sentinel] use alert name to verify if prevented

### DIFF
--- a/microsoft-sentinel/src/openbas_microsoft_sentinel.py
+++ b/microsoft-sentinel/src/openbas_microsoft_sentinel.py
@@ -162,16 +162,22 @@ class OpenBASMicrosoftSentinel:
 
     def _is_prevented(self, columns_index, alert):
         extended_properties = json.loads(alert[columns_index["ExtendedProperties"]])
-        if "Action" in extended_properties and extended_properties["Action"] in [
-            "blocked",
-            "quarantine",
-            "remove",
-        ]:
-            return True
-        return False
+        result_action = (
+            True
+            if "Action" in extended_properties
+            and extended_properties["Action"]
+            in [
+                "blocked",
+                "quarantine",
+                "remove",
+            ]
+            else False
+        )
+        alert_name = alert[columns_index["AlertName"]]
+        result_alert_name = True if "prevented" in alert_name.strip().lower() else False
+        return result_action or result_alert_name
 
     def _match_alert(self, endpoint, columns_index, alert, expectation):
-        print(alert)
         self.helper.collector_logger.info(
             "Trying to match alert "
             + str(alert[columns_index["SystemAlertId"]])
@@ -306,7 +312,6 @@ class OpenBASMicrosoftSentinel:
                 alert_date = parse(
                     str(alert[columns_index["TimeGenerated"]])
                 ).astimezone(pytz.UTC)
-                print(alert)
                 if alert_date > limit_date:
                     result = self._match_alert(
                         endpoint, columns_index, alert, expectation


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* use alert name to verify if prevented

### Related issues

* Closes https://github.com/OpenBAS-Platform/openbas/issues/1757

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
