### PR TITLE
[microsoft-sentinel/microsoft-defender] Improve matching to identify Prevented and add match on parent process name (#1757)

### DIFF
--- a/microsoft-defender/src/openbas_microsoft_defender.py
+++ b/microsoft-defender/src/openbas_microsoft_defender.py
@@ -106,8 +106,13 @@ class OpenBASMicrosoftDefender:
     def _extract_parent_process_name(self, alert):
         parent_process_names = []
         for evidence in alert.evidence:
-            if hasattr(evidence, 'parent_process_image_file') and evidence.parent_process_image_file:
-                parent_process_names.append(evidence.parent_process_image_file.file_name)
+            if (
+                hasattr(evidence, "parent_process_image_file")
+                and evidence.parent_process_image_file
+            ):
+                parent_process_names.append(
+                    evidence.parent_process_image_file.file_name
+                )
         return parent_process_names
 
     def _extract_command_lines(self, alert):
@@ -283,7 +288,9 @@ class OpenBASMicrosoftDefender:
             )
             for i in range(len(alerts.value)):
                 alert = alerts.value[i]
-                alert_date = parse(str(alert.last_update_date_time)).astimezone(pytz.UTC)
+                alert_date = parse(str(alert.last_update_date_time)).astimezone(
+                    pytz.UTC
+                )
                 if alert_date > limit_date:
                     result = self._match_alert(endpoint, alert, expectation)
                     if result is not False:

--- a/microsoft-defender/src/openbas_microsoft_defender.py
+++ b/microsoft-defender/src/openbas_microsoft_defender.py
@@ -77,6 +77,7 @@ class OpenBASMicrosoftDefender:
         # TODO Command line
         # self.relevant_signatures_types = ["process_name", "command_line", "file_name", "hostname", "ipv4_address"]
         self.relevant_signatures_types = [
+            "parent_process_name",
             "process_name",
             "file_name",
             "hostname",
@@ -101,6 +102,13 @@ class OpenBASMicrosoftDefender:
             elif evidence.odata_type == "#microsoft.graph.security.fileEvidence":
                 process_names.append(evidence.file_details.file_name)
         return process_names
+
+    def _extract_parent_process_name(self, alert):
+        parent_process_names = []
+        for evidence in alert.evidence:
+            if hasattr(evidence, 'parent_process_image_file') and evidence.parent_process_image_file:
+                parent_process_names.append(evidence.parent_process_image_file.file_name)
+        return parent_process_names
 
     def _extract_command_lines(self, alert):
         command_lines = []
@@ -134,7 +142,7 @@ class OpenBASMicrosoftDefender:
     def _is_prevented(self, alert):
         for evidence in alert.evidence:
             if evidence.odata_type == "#microsoft.graph.security.processEvidence":
-                if evidence.detection_status in [
+                if evidence.detection_status.lower() in [
                     "prevented",
                     "remediated",
                     "blocked",
@@ -172,6 +180,12 @@ class OpenBASMicrosoftDefender:
                 alert_data[type] = {
                     "type": "fuzzy",
                     "data": self._extract_process_names(alert),
+                    "score": 80,
+                }
+            elif type == "parent_process_name":
+                alert_data[type] = {
+                    "type": "fuzzy",
+                    "data": self._extract_parent_process_name(alert),
                     "score": 80,
                 }
             elif type == "command_line":
@@ -269,7 +283,7 @@ class OpenBASMicrosoftDefender:
             )
             for i in range(len(alerts.value)):
                 alert = alerts.value[i]
-                alert_date = parse(str(alert.created_date_time)).astimezone(pytz.UTC)
+                alert_date = parse(str(alert.last_update_date_time)).astimezone(pytz.UTC)
                 if alert_date > limit_date:
                     result = self._match_alert(endpoint, alert, expectation)
                     if result is not False:

--- a/microsoft-sentinel/src/openbas_microsoft_sentinel.py
+++ b/microsoft-sentinel/src/openbas_microsoft_sentinel.py
@@ -161,21 +161,12 @@ class OpenBASMicrosoftSentinel:
         return ip_addresses
 
     def _is_prevented(self, columns_index, alert):
-        extended_properties = json.loads(alert[columns_index["ExtendedProperties"]])
-        result_action = (
-            True
-            if "Action" in extended_properties
-            and extended_properties["Action"]
-            in [
-                "blocked",
-                "quarantine",
-                "remove",
-            ]
-            else False
+        prevented_keywords = ["blocked", "quarantine", "remove", "prevented"]
+        alert_name = alert[columns_index["AlertName"]].strip().lower()
+        result_alert_name = any(
+            prevented_keyword in alert_name for prevented_keyword in prevented_keywords
         )
-        alert_name = alert[columns_index["AlertName"]]
-        result_alert_name = True if "prevented" in alert_name.strip().lower() else False
-        return result_action or result_alert_name
+        return result_alert_name
 
     def _match_alert(self, endpoint, columns_index, alert, expectation):
         self.helper.collector_logger.info(

--- a/microsoft-sentinel/src/openbas_microsoft_sentinel.py
+++ b/microsoft-sentinel/src/openbas_microsoft_sentinel.py
@@ -162,16 +162,22 @@ class OpenBASMicrosoftSentinel:
 
     def _is_prevented(self, columns_index, alert):
         extended_properties = json.loads(alert[columns_index["ExtendedProperties"]])
-        if "Action" in extended_properties and extended_properties["Action"] in [
-            "blocked",
-            "quarantine",
-            "remove",
-        ]:
-            return True
-        return False
+        result_action = (
+            True
+            if "Action" in extended_properties
+            and extended_properties["Action"]
+            in [
+                "blocked",
+                "quarantine",
+                "remove",
+            ]
+            else False
+        )
+        alert_name = alert[columns_index["AlertName"]]
+        result_alert_name = True if "prevented" in alert_name.strip().lower() else False
+        return result_action or result_alert_name
 
     def _match_alert(self, endpoint, columns_index, alert, expectation):
-        print(alert)
         self.helper.collector_logger.info(
             "Trying to match alert "
             + str(alert[columns_index["SystemAlertId"]])
@@ -306,7 +312,6 @@ class OpenBASMicrosoftSentinel:
                 alert_date = parse(
                     str(alert[columns_index["TimeGenerated"]])
                 ).astimezone(pytz.UTC)
-                print(alert)
                 if alert_date > limit_date:
                     result = self._match_alert(
                         endpoint, columns_index, alert, expectation

--- a/microsoft-sentinel/src/openbas_microsoft_sentinel.py
+++ b/microsoft-sentinel/src/openbas_microsoft_sentinel.py
@@ -129,8 +129,13 @@ class OpenBASMicrosoftSentinel:
         for entity in entities:
             if "Type" in entity and entity["Type"] == "process":
                 if "ParentProcess" in entity and "ImageFile" in entity["ParentProcess"]:
-                    if "ImageFile" in entity["ParentProcess"] and "Name" in entity["ParentProcess"]["ImageFile"]:
-                        parent_process_names.append(entity["ParentProcess"]["ImageFile"]["Name"])
+                    if (
+                        "ImageFile" in entity["ParentProcess"]
+                        and "Name" in entity["ParentProcess"]["ImageFile"]
+                    ):
+                        parent_process_names.append(
+                            entity["ParentProcess"]["ImageFile"]["Name"]
+                        )
         return parent_process_names
 
     def _extract_command_lines(self, columns_index, alert):


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* [microsoft-sentinel]: Use alert name to verify if prevented
* [microsoft-sentinel]: Add match on parent_process_name
* [microsoft-defender]: Add match on parent_process_name
* [microsoft-defender]: Use last_update_date_time for alert_date

### Related issues

* Closes https://github.com/OpenBAS-Platform/openbas/issues/1757

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
