### PR TITLE
null cleanup executor if command is absent (OpenBAS-Platform/openbas/issues/1621)

### DIFF
--- a/atomic-red-team/src/openbas_atomic_red_team.py
+++ b/atomic-red-team/src/openbas_atomic_red_team.py
@@ -145,7 +145,9 @@ class OpenBASAtomicRedTeam:
                         )
                         platforms.sort()
                         cleanup_command = atomic_test["executor"].get("cleanup_command")
-                        cleanup_command = None if cleanup_command == '' else cleanup_command
+                        cleanup_command = (
+                            None if cleanup_command == "" else cleanup_command
+                        )
                         payload = {
                             "payload_source": "COMMUNITY",
                             "payload_status": (
@@ -167,9 +169,11 @@ class OpenBASAtomicRedTeam:
                             ],
                             "command_content": atomic_test["executor"]["command"],
                             "payload_cleanup_command": cleanup_command,
-                            "payload_cleanup_executor": EXECUTORS[
-                                atomic_test["executor"]["name"]
-                            ] if cleanup_command else None,
+                            "payload_cleanup_executor": (
+                                EXECUTORS[atomic_test["executor"]["name"]]
+                                if cleanup_command
+                                else None
+                            ),
                             "payload_elevation_required": atomic_test["executor"].get(
                                 "elevation_required", False
                             ),

--- a/atomic-red-team/src/openbas_atomic_red_team.py
+++ b/atomic-red-team/src/openbas_atomic_red_team.py
@@ -144,6 +144,8 @@ class OpenBASAtomicRedTeam:
                             )
                         )
                         platforms.sort()
+                        cleanup_command = atomic_test["executor"].get("cleanup_command")
+                        cleanup_command = None if cleanup_command == '' else cleanup_command
                         payload = {
                             "payload_source": "COMMUNITY",
                             "payload_status": (
@@ -164,12 +166,10 @@ class OpenBASAtomicRedTeam:
                                 atomic_test["executor"]["name"]
                             ],
                             "command_content": atomic_test["executor"]["command"],
-                            "payload_cleanup_command": atomic_test["executor"].get(
-                                "cleanup_command", None
-                            ),
+                            "payload_cleanup_command": cleanup_command,
                             "payload_cleanup_executor": EXECUTORS[
                                 atomic_test["executor"]["name"]
-                            ],
+                            ] if cleanup_command else None,
                             "payload_elevation_required": atomic_test["executor"].get(
                                 "elevation_required", False
                             ),


### PR DESCRIPTION


### Proposed changes

* Don't input a cleanup executor if the cleanup command is absent from the payload data

### Related issues

* OpenBAS-Platform/openbas/issues/1621

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
