### PR TITLE
[microsoft-defender] Ensure complete signature process evidence is accounted for in Defender API query

### DIFF
--- a/microsoft-defender/src/openbas_microsoft_defender.py
+++ b/microsoft-defender/src/openbas_microsoft_defender.py
@@ -93,7 +93,7 @@ let tree = hashedProcessEvents
     | join kind=inner hashedProcessEvents on $left.parent_hash == $right.process_hash
     | make-graph process_hash --> process_hash1 with hashedProcessEvents on process_hash
     | graph-match (parent)<-[spawnedBy*1..100]-(child)
-        project child.process_hash, child.ProcessId, child.FileName, child.ProcessCommandLine, child.ProcessCreationTime, parent.ProcessId, parent.FileName, parent.ProcessCommandLine, parent.ProcessCreationTime, Path = strcat(spawnedBy.ProcessId, " ", spawnedBy.ProcessCommandLine), sig=coalesce(null_if_not_implant_sig(child.FileName), null_if_not_implant_sig(parent.FileName))
+        project child.process_hash, child.ProcessId, child.FileName, child.ProcessCommandLine, child.ProcessCreationTime, parent.ProcessId, parent.FileName, parent.ProcessCommandLine, parent.ProcessCreationTime, Path = strcat(spawnedBy.ProcessId, " ", spawnedBy.ProcessCommandLine), sig=normalisePath(coalesce(null_if_not_implant_sig(child.FileName), null_if_not_implant_sig(parent.FileName)))
     | extend PathLength = array_length(Path)
     | where isnotempty(sig);
 fileEvidence


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Fix query to coalesce normalised image file names for complete AlertEvidence process ancestry so as to account for Evidence spawned directly from a process with a signature filename (and not only evidence spawned by a child of such a process)

### Related issues

* Contributes https://github.com/OpenBAS-Platform/openbas/issues/1686
*

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->

### Further comments

If there is a match between the File or Process Evidence and the process tree, consign either the leaf "child" process of the tree occurrence, or the found signature parent, into the "ParentProcessImageFileName" column. Previously to this change, only example 2 would have worked.

Example 1:
```
Evidence --match--> Process "obas-implant-XXX123" --parent--> "powershell.exe"
```
Result:
```
ParentProcessImageFileName: "obas-implant-XXX123"
```

Example 2:
```
Evidence --match--> Process "bash" --parent--> "bash" --parent--> "obas-implant-XXX456"
```
Result:
```
ParentProcessImageFileName: "obas-implant-XXX456"
```