### PR TITLE
[microsoft-defender/microsoft-entra] fix image builds on python 3.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,27 +55,27 @@ jobs:
       - run:
           working_directory: ~/openbas/mitre-attack
           name: Build Docker image openbas/collector-mitre-attack
-          command: docker build -t openbas/collector-mitre-attack:latest . && docker tag openbas/collector-mitre-attack:latest openbas/collector-mitre-attack:${CIRCLE_TAG}
+          command: docker build --progress=plain -t openbas/collector-mitre-attack:latest . && docker tag openbas/collector-mitre-attack:latest openbas/collector-mitre-attack:${CIRCLE_TAG}
       - run:
           working_directory: ~/openbas/microsoft-entra
           name: Build Docker image openbas/collector-microsoft-entra
-          command: docker build -t openbas/collector-microsoft-entra:latest . && docker tag openbas/collector-microsoft-entra:latest openbas/collector-microsoft-entra:${CIRCLE_TAG}
+          command: docker build --progress=plain -t openbas/collector-microsoft-entra:latest . && docker tag openbas/collector-microsoft-entra:latest openbas/collector-microsoft-entra:${CIRCLE_TAG}
       - run:
           working_directory: ~/openbas/tanium-threat-response
           name: Build Docker image openbas/collector-tanium-threat-response
-          command: docker build -t openbas/collector-tanium-threat-response:latest . && docker tag openbas/collector-tanium-threat-response:latest openbas/collector-tanium-threat-response:${CIRCLE_TAG}
+          command: docker build --progress=plain -t openbas/collector-tanium-threat-response:latest . && docker tag openbas/collector-tanium-threat-response:latest openbas/collector-tanium-threat-response:${CIRCLE_TAG}
       - run:
           working_directory: ~/openbas/microsoft-defender
           name: Build Docker image openbas/collector-microsoft-defender
-          command: docker build -t openbas/collector-microsoft-defender:latest . && docker tag openbas/collector-microsoft-defender:latest openbas/collector-microsoft-defender:${CIRCLE_TAG}
+          command: docker build --progress=plain -t openbas/collector-microsoft-defender:latest . && docker tag openbas/collector-microsoft-defender:latest openbas/collector-microsoft-defender:${CIRCLE_TAG}
       - run:
           working_directory: ~/openbas/microsoft-sentinel
           name: Build Docker image openbas/collector-microsoft-sentinel
-          command: docker build -t openbas/collector-microsoft-sentinel:latest . && docker tag openbas/collector-microsoft-sentinel:latest openbas/collector-microsoft-sentinel:${CIRCLE_TAG}
+          command: docker build --progress=plain -t openbas/collector-microsoft-sentinel:latest . && docker tag openbas/collector-microsoft-sentinel:latest openbas/collector-microsoft-sentinel:${CIRCLE_TAG}
       - run:
           working_directory: ~/openbas/atomic-red-team
           name: Build Docker image openbas/collector-atomic-red-team
-          command: docker build -t openbas/collector-atomic-red-team:latest . && docker tag openbas/collector-atomic-red-team:latest openbas/collector-atomic-red-team:${CIRCLE_TAG}
+          command: docker build --progress=plain -t openbas/collector-atomic-red-team:latest . && docker tag openbas/collector-atomic-red-team:latest openbas/collector-atomic-red-team:${CIRCLE_TAG}
       - run:
           name: Publish Docker Image to Docker Hub
           command: |
@@ -109,27 +109,27 @@ jobs:
       - run:
           working_directory: ~/openbas/mitre-attack
           name: Build Docker image openbas/collector-mitre-attack
-          command: docker build -t openbas/collector-mitre-attack:rolling .
+          command: docker build --progress=plain -t openbas/collector-mitre-attack:rolling .
       - run:
           working_directory: ~/openbas/microsoft-entra
           name: Build Docker image openbas/collector-microsoft-entra
-          command: docker build -t openbas/collector-microsoft-entra:rolling .
+          command: docker build --progress=plain -t openbas/collector-microsoft-entra:rolling .
       - run:
           working_directory: ~/openbas/tanium-threat-response
           name: Build Docker image openbas/collector-tanium-threat-response
-          command: docker build -t openbas/collector-tanium-threat-response:rolling .
+          command: docker build --progress=plain -t openbas/collector-tanium-threat-response:rolling .
       - run:
           working_directory: ~/openbas/microsoft-defender
           name: Build Docker image openbas/collector-microsoft-defender
-          command: docker build -t openbas/collector-microsoft-defender:rolling .
+          command: docker build --progress=plain -t openbas/collector-microsoft-defender:rolling .
       - run:
           working_directory: ~/openbas/microsoft-sentinel
           name: Build Docker image openbas/collector-microsoft-sentinel
-          command: docker build -t openbas/collector-microsoft-sentinel:rolling .
+          command: docker build --progress=plain -t openbas/collector-microsoft-sentinel:rolling .
       - run:
           working_directory: ~/openbas/atomic-red-team
           name: Build Docker image openbas/collector-atomic-red-team
-          command: docker build -t openbas/collector-atomic-red-team:rolling .
+          command: docker build --progress=plain -t openbas/collector-atomic-red-team:rolling .
       - run:
           name: Publish Docker Image to Docker Hub
           command: |

--- a/microsoft-defender/Dockerfile
+++ b/microsoft-defender/Dockerfile
@@ -6,10 +6,10 @@ COPY src /opt/openbas-collector-microsoft-defender
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apk update && apk upgrade && \
-    apk --no-cache add git build-base libmagic libffi-dev libxslt libxslt-dev libxml2 libxml2-dev && \
+    apk --no-cache add git build-base libmagic libffi-dev libxslt libxslt-dev libxml2 libxml2-dev rust cargo && \
     cd /opt/openbas-collector-microsoft-defender && \
     pip3 install --no-cache-dir -r requirements.txt && \
-    apk del git build-base
+    apk del git build-base rust cargo libffi-dev libxslt-dev libxml2-dev
 
 # Expose and entrypoint
 COPY entrypoint.sh /

--- a/microsoft-entra/Dockerfile
+++ b/microsoft-entra/Dockerfile
@@ -6,10 +6,10 @@ COPY src /opt/openbas-collector-microsoft-entra
 # Install Python modules
 # hadolint ignore=DL3003
 RUN apk update && apk upgrade && \
-    apk --no-cache add git build-base libmagic libffi-dev libxslt libxslt-dev libxml2 libxml2-dev && \
+    apk --no-cache add git build-base libmagic libffi-dev libxslt libxslt-dev libxml2 libxml2-dev rust cargo  && \
     cd /opt/openbas-collector-microsoft-entra && \
     pip3 install --no-cache-dir -r requirements.txt && \
-    apk del git build-base
+    apk del git build-base rust cargo libffi-dev libxslt-dev libxml2-dev
 
 # Expose and entrypoint
 COPY entrypoint.sh /


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

Some python dependencies may not exist as prebuilt wheels on pypi and therefore pip tries to build them by itself. Some of these dependencies require additional toolchains (here: rust) to be built.

### Proposed changes

* Fixes building packages not available as wheels on pypi
* Adds then removes a rust toolchain on specific images
* Enables full log retention for build platform to ease diagnostics

### Related issues

* N/A

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->