### PR TITLE
[microsoft-defender] change implementation to not use TimeGenerated (#2035)

### DIFF
--- a/microsoft-defender/src/openbas_microsoft_defender.py
+++ b/microsoft-defender/src/openbas_microsoft_defender.py
@@ -74,7 +74,7 @@ let augmentedAllFilesEvents = augmentedDeviceEvents
     | distinct DeviceId, normalised_filename, normalised_folder_path, process_hash;
 let singleMachinePerAlert = AlertEvidence
     | where EntityType has "Machine" and EvidenceRole has "Impacted"
-    | summarize max(TimeGenerated) by AlertId, DeviceId, DeviceName;
+    | distinct AlertId, DeviceId, DeviceName;
 let fileEvidence = singleMachinePerAlert
     | join AlertEvidence on $left.AlertId == $right.AlertId
     | where EntityType has "File"


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the OpenBAS project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* Change query to not use TimeGenerated

A customer came back saying their version of the Threat Hunting schema did not have TimeGenerated columns on tables, contrary to our own. A mistake was made to rely on this column in the query that fetched alerts from the MDE backend.

### Related issues

* Fix https://github.com/OpenBAS-Platform/openbas/issues/2035

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality using different use cases
- [x] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality

<!-- For completed items, change [ ] to [x]. -->
