### PR TITLE
Update openbas_microsoft_defender.py to use 'map' function

### DIFF
--- a/microsoft-defender/src/openbas_microsoft_defender.py
+++ b/microsoft-defender/src/openbas_microsoft_defender.py
@@ -93,7 +93,7 @@ let tree = hashedProcessEvents
     | join kind=inner hashedProcessEvents on $left.parent_hash == $right.process_hash
     | make-graph process_hash --> process_hash1 with hashedProcessEvents on process_hash
     | graph-match (parent)<-[spawnedBy*1..100]-(child)
-        project child.process_hash, child.ProcessId, child.FileName, child.ProcessCommandLine, child.ProcessCreationTime, parent.ProcessId, parent.FileName, parent.ProcessCommandLine, parent.ProcessCreationTime, Path = strcat(spawnedBy.ProcessId, " ", spawnedBy.ProcessCommandLine), sig=normalisePath(coalesce(null_if_not_implant_sig(child.FileName), null_if_not_implant_sig(parent.FileName)))
+        project child.process_hash, child.ProcessId, child.FileName, child.ProcessCommandLine, child.ProcessCreationTime, parent.ProcessId, parent.FileName, parent.ProcessCommandLine, parent.ProcessCreationTime, Path = map(spawnedBy, strcat(ProcessId, " ", ProcessCommandLine)), sig=normalisePath(coalesce(null_if_not_implant_sig(child.FileName), null_if_not_implant_sig(parent.FileName)))
     | extend PathLength = array_length(Path)
     | where isnotempty(sig);
 fileEvidence


### PR DESCRIPTION
Updating query kql to use 'map' function over variable edge - https://learn.microsoft.com/en-us/kusto/query/map-graph-function?view=microsoft-fabric. Current syntax was deprecated - https://techcommunity.microsoft.com/blog/azuredataexplorer/deprecation-of-variable-length-edge-dot-notation-in-graph-match/4399470

<!--
Thank you very much for your pull request to the OpenBAS project! We as a community driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

* replace variable edge dot notation usage with call to 'map' function (https://learn.microsoft.com/en-us/kusto/query/map-graph-function?view=microsoft-fabric)

### Related issues

* query fails on some clusters, due to syntax deprecation - https://techcommunity.microsoft.com/blog/azuredataexplorer/deprecation-of-variable-length-edge-dot-notation-in-graph-match/4399470

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenBAS project.
-->

- [ X ] I consider the submitted work as finished
- [ ] I tested the code for its functionality using different use cases
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
