### PR TITLE
[collectors] fix(ci): allow underscores and dashes in PR title scope (#337)

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -20,7 +20,7 @@ jobs:
           
           # Regex for:
           # [category/subcategory] type(scope?): description (#123?)
-          PATTERN='^\[([a-z]+(/[a-z]+)*)\] (feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(\([a-z]+\))?: [a-z].*( \(#[0-9]+\))$'
+          PATTERN='^\[([a-z]+(/[a-z]+)*)\] (feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(\([a-z][a-z_-]*\))?: [a-z].*( \(#[0-9]+\))$'
           
           if [[ ! "$TITLE" =~ $PATTERN ]]; then
             echo "❌ Invalid PR title."

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,32 +1,25 @@
-name: "Validate PR Title"
+name: "[OpenAEV] Validate PR title Worker"
 
 on:
   pull_request:
-    types: [ opened, edited, reopened, ready_for_review, synchronize ]
+    branches: [main, release/current]
+    types: [opened, edited, reopened, ready_for_review, synchronize]
+
+permissions:
+  contents: read
 
 jobs:
   validate-pr-title:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-
     steps:
-      - name: Check PR title format
-        shell: bash
-        run: |
-          TITLE="${{ github.event.pull_request.title }}"
-          echo "PR title: $TITLE"
-          
-          # Regex for:
-          # [category/subcategory] type(scope?): description (#123?)
-          PATTERN='^\[([a-z]+(/[a-z]+)*)\] (feat|fix|chore|docs|style|refactor|perf|test|build|ci|revert)(\([a-z][a-z_-]*\))?: [a-z].*( \(#[0-9]+\))$'
-          
-          if [[ ! "$TITLE" =~ $PATTERN ]]; then
-            echo "❌ Invalid PR title."
-            echo "Required format:"
-            echo "[category] type(scope?): description (#123)"
-            exit 1
-          fi
-          
-          echo "✅ PR title is valid."
+      - name: "Generate a token"
+        id: generate-token
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.OPENAEV_PR_CHECKS_APP_ID }}
+          private-key: ${{ secrets.OPENAEV_PR_CHECKS_PRIVATE_KEY }}
+      - name: "Validate PR title and create check"
+        uses: FiligranHQ/filigran-ci-tools/actions/pr-title-check@main
+        with:
+          token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Summary

Fixes #337

Instead of fixing the scope regex locally, this PR adopts the shared `FiligranHQ/filigran-ci-tools/actions/pr-title-check@main` action — the same pattern already used in `client-python`.

## Changes

Replaced the entire inline bash regex validation in `validate-pr-title.yml` with the shared action, which provides:
- ✅ Underscore and dash support in scopes (via [filigran-ci-tools PR #3](https://github.com/FiligranHQ/filigran-ci-tools/pull/3))
- ✅ Renovate PR skipping (built-in `chore(deps)` detection)
- ✅ Merge commit skipping
- ✅ Diagnostic check runs with detailed failure reasons
- ✅ Centralized maintenance — regex fixes propagate to all repos automatically

## Dependency

Requires [FiligranHQ/filigran-ci-tools#3](https://github.com/FiligranHQ/filigran-ci-tools/pull/3) to be merged first for the underscore fix to take effect (this PR references `@main`).