### PR TITLE
feat(openaev): tag imported payload samples as malware samples (#522)

### DIFF
--- a/openaev/openaev/openaev_openaev.py
+++ b/openaev/openaev/openaev_openaev.py
@@ -106,6 +106,10 @@ class OpenAEVOpenAEV(CollectorDaemon):
                     if tag_id in tags_mapping:
                         new_tags.append(tags_mapping[tag_id])
                 document["document_tags"] = new_tags
+                # Community payload samples are malware: OpenAEV re-encrypts them at
+                # rest as a password-protected archive and the implant decrypts them
+                # on the fly before detonation.
+                document["document_kind"] = "MALWARE_SAMPLE"
 
                 zip_url = openaev_url_prefix + document["document_path"]
                 zip_response = self.session.get(zip_url)


### PR DESCRIPTION
The openaev collector imports community payloads whose sample ships as an 'infected'-password zip; it unzips to plaintext and uploads via document upsert. This tags those uploads with document_kind = MALWARE_SAMPLE so OpenAEV re-encrypts them at rest and the implant decrypts on the fly before detonation.

Pairs with OpenAEV-Platform/openaev#6842 and OpenAEV-Platform/implant#164.

## Test plan
- [ ] Run the openaev collector import and confirm the payload sample document is stored encrypted (document_encrypted = true).