### PR TITLE
fix(mitre-attack): set kill chain phase order for ATT&CK tactics (#558)

### DIFF
--- a/mitre-attack/README.md
+++ b/mitre-attack/README.md
@@ -30,7 +30,8 @@ OpenAEV (Breach and Attack Simulation) relies on a shared library of kill chain 
 and organize the attacks it simulates. This collector keeps that library aligned with MITRE ATT&CK. On each run it
 fetches the Enterprise ATT&CK STIX bundle published in the public `mitre/cti` GitHub repository and upserts:
 
-- ATT&CK tactics as kill chain phases (kill chain name `mitre-attack`).
+- ATT&CK tactics as kill chain phases (kill chain name `mitre-attack`), each tagged with a canonical phase order so the
+  ATT&CK tactics render left-to-right in the canonical matrix sequence in OpenAEV.
 - ATT&CK techniques and sub-techniques as attack patterns, preserving the sub-technique to parent technique
   relationship, the associated kill chain phases, platforms, and required permissions.
 
@@ -124,7 +125,8 @@ On each run, the collector:
 1. Downloads the Enterprise ATT&CK STIX bundle from the public MITRE CTI GitHub repository.
 2. Splits the STIX objects into tactics (`x-mitre-tactic`), attack patterns (`attack-pattern`, excluding revoked ones),
    and `subtechnique-of` relationships.
-3. Upserts the tactics as kill chain phases (kill chain name `mitre-attack`).
+3. Upserts the tactics as kill chain phases (kill chain name `mitre-attack`), applying the canonical ATT&CK matrix
+   order as each phase's order.
 4. Upserts the techniques and sub-techniques as attack patterns, linking each to its kill chain phases and, for
    sub-techniques, to its parent technique.
 

--- a/mitre-attack/mitre_attack/openaev_mitre.py
+++ b/mitre-attack/mitre_attack/openaev_mitre.py
@@ -7,6 +7,31 @@ ENTERPRISE_ATTACK_URI = (
     "https://github.com/mitre/cti/raw/master/enterprise-attack/enterprise-attack.json"
 )
 
+# Canonical Enterprise ATT&CK matrix tactic order, keyed by tactic short name. Sent as phase_order
+# so the platform renders the ATT&CK tactics left-to-right in the canonical matrix sequence
+# (kill chain phases otherwise default to order 0 and fall back to alphabetical ordering).
+ATTACK_TACTIC_ORDER = {
+    "reconnaissance": 0,
+    "resource-development": 1,
+    "initial-access": 2,
+    "execution": 3,
+    "persistence": 4,
+    "privilege-escalation": 5,
+    "defense-evasion": 6,
+    "credential-access": 7,
+    "discovery": 8,
+    "lateral-movement": 9,
+    "collection": 10,
+    "command-and-control": 11,
+    "exfiltration": 12,
+    "impact": 13,
+}
+
+# Tactics absent from ATTACK_TACTIC_ORDER (e.g. introduced by a future ATT&CK release) are
+# ordered after all known tactics instead of at the front (order 0), so the canonical
+# ordering of the known phases is preserved.
+UNKNOWN_TACTIC_ORDER = max(ATTACK_TACTIC_ORDER.values()) + 1
+
 
 class OpenAEVMitre(CollectorDaemon):
     def __init__(
@@ -40,6 +65,9 @@ class OpenAEVMitre(CollectorDaemon):
                 "phase_shortname": phase_shortname,
                 "phase_name": phase_name,
                 "phase_description": phase_description,
+                "phase_order": ATTACK_TACTIC_ORDER.get(
+                    phase_shortname, UNKNOWN_TACTIC_ORDER
+                ),
             }
             kill_chain_phases.append(kill_chain_phase)
         result = self.api.kill_chain_phase.upsert(kill_chain_phases)


### PR DESCRIPTION
## Summary

- The `mitre-attack` collector upserts ATT&CK tactics as kill chain phases but never set `phase_order`, so every imported ATT&CK tactic landed with the backend default `phase_order = 0`.
- Anywhere the platform orders phases by `phase_order` (e.g. the "Logic" tab of a chained scenario, which groups injects into one column per MITRE tactic), the tactics all tied on `0` and fell back to an alphabetical tiebreaker instead of the canonical ATT&CK matrix order.
- This mirrors the existing `mitre-atlas` collector, which already ships a canonical `ATLAS_TACTIC_ORDER` map and sends it as `phase_order`. This PR adds the equivalent `ATTACK_TACTIC_ORDER` map (keyed by tactic short name) and sets `phase_order` when upserting kill chain phases.

Tactics now render left-to-right in the canonical order: Reconnaissance -> Resource Development -> Initial Access -> Execution -> Persistence -> Privilege Escalation -> Defense Evasion -> Credential Access -> Discovery -> Lateral Movement -> Collection -> Command and Control -> Exfiltration -> Impact.

Unknown / future tactics are ordered after all known ones (never at the front), matching the ATLAS collector's behavior.

## Notes

- No backend or frontend change is required: the platform already sorts by `phase_order`.
- The change is idempotent; existing installs pick up the correct order on the next collector run (the upsert updates phases in place).

Closes #558
