### PR TITLE
fix(microsoft-defender-o365): invalid filter clause when filtering with datetime (#564)

### DIFF
--- a/microsoft-defender-o365/src/source/defender_o365_data_fetcher.py
+++ b/microsoft-defender-o365/src/source/defender_o365_data_fetcher.py
@@ -156,6 +156,7 @@ class DefenderO365DataFetcher:
                 response.raise_for_status()
                 break
 
+            response.raise_for_status()
             data = response.json()
 
             if not isinstance(data, dict):

--- a/microsoft-defender-o365/src/source/source_handler.py
+++ b/microsoft-defender-o365/src/source/source_handler.py
@@ -18,8 +18,12 @@ class DefenderO365SourceHandler(SourceHandler):
                 try:
                     dt = datetime.fromisoformat(sig.value)
 
-                    if not dt.tzinfo:
+                    if dt.tzinfo:
+                        # if there is a timezone, we convert it to UTC
                         dt = dt.astimezone(UTC)
+                    else:
+                        # we consider, if the END_DATE is naive, that is was produced as UTC
+                        dt = dt.replace(tzinfo=UTC)
                 except (ValueError, TypeError):
                     continue
                 if earliest is None or dt < earliest:

--- a/microsoft-defender-o365/src/source/source_handler.py
+++ b/microsoft-defender-o365/src/source/source_handler.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from pyoaev.signatures.types import SignatureTypes
 from src.collector.models.source import SourceHandler
@@ -17,6 +17,9 @@ class DefenderO365SourceHandler(SourceHandler):
                     continue
                 try:
                     dt = datetime.fromisoformat(sig.value)
+
+                    if not dt.tzinfo:
+                        dt = dt.astimezone(UTC)
                 except (ValueError, TypeError):
                     continue
                 if earliest is None or dt < earliest:
@@ -27,7 +30,7 @@ class DefenderO365SourceHandler(SourceHandler):
 
         def _hook(params: dict) -> dict:
             current = params.get("$filter", "")
-            clause = f"createdDateTime ge {earliest.astimezone().isoformat()}"
+            clause = f"createdDateTime ge {earliest.isoformat()}"
             params["$filter"] = f"{current} and {clause}" if current else clause
             return params
 

--- a/microsoft-defender-o365/src/source/source_handler.py
+++ b/microsoft-defender-o365/src/source/source_handler.py
@@ -27,7 +27,7 @@ class DefenderO365SourceHandler(SourceHandler):
 
         def _hook(params: dict) -> dict:
             current = params.get("$filter", "")
-            clause = f"createdDateTime ge {earliest.isoformat()}"
+            clause = f"createdDateTime ge {earliest.astimezone().isoformat()}"
             params["$filter"] = f"{current} and {clause}" if current else clause
             return params
 

--- a/microsoft-defender-o365/src/source/source_handler.py
+++ b/microsoft-defender-o365/src/source/source_handler.py
@@ -27,7 +27,7 @@ class DefenderO365SourceHandler(SourceHandler):
 
         def _hook(params: dict) -> dict:
             current = params.get("$filter", "")
-            clause = f"createdDateTime ge '{earliest.isoformat()}'"
+            clause = f"createdDateTime ge {earliest.isoformat()}"
             params["$filter"] = f"{current} and {clause}" if current else clause
             return params
 


### PR DESCRIPTION
### Proposed changes

* Withdrawing single quote for the datetime param
* Adding timezone to the datetime param

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #564 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->
