### PR TITLE
refactor(template): adding str safeguard to alert_link (#566)

### DIFF
--- a/microsoft-defender-o365/src/collector/models/expectations.py
+++ b/microsoft-defender-o365/src/collector/models/expectations.py
@@ -203,7 +203,7 @@ class ExpectationTrace(BaseModel):
         """
         matching_data = result.matched_alerts[0] or {}
         alert_name = matching_data.get("alert_name", f"{collector_name} Alert")
-        trace_link = matching_data.get("alert_link", "")
+        trace_link = str(matching_data.get("alert_link", ""))
         trace_date = datetime.now(UTC).replace(microsecond=0)
         date_str = trace_date.isoformat().replace("+00:00", "Z")
         return cls(

--- a/template/src/collector/models/expectations.py
+++ b/template/src/collector/models/expectations.py
@@ -203,7 +203,7 @@ class ExpectationTrace(BaseModel):
         """
         matching_data = result.matched_alerts[0] or {}
         alert_name = matching_data.get("alert_name", f"{collector_name} Alert")
-        trace_link = matching_data.get("alert_link", "")
+        trace_link = str(matching_data.get("alert_link", ""))
         trace_date = datetime.now(UTC).replace(microsecond=0)
         date_str = trace_date.isoformat().replace("+00:00", "Z")
         return cls(


### PR DESCRIPTION
### Proposed changes

* Adding an str cast to `alert_link` as a safeguard in case the provided element is made using `pydantic` url-oriented types rather than str

### Testing Instructions

1. Step-by-step how to test
2. Environment or config notes

### Related issues

* Closes #566 

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->
