### PR TITLE
fix(template/microsoft-defender-o365): source signature typing issues (#568)

### DIFF
--- a/microsoft-defender-o365/src/collector/engines/basic.py
+++ b/microsoft-defender-o365/src/collector/engines/basic.py
@@ -7,7 +7,7 @@ from pyoaev.apis.inject_expectation.model import (  # type: ignore[import-untype
 )
 from pyoaev.client import OpenAEV  # type: ignore[import-untyped]
 from pyoaev.helpers import OpenAEVDetectionHelper  # type: ignore[import-untyped]
-from pyoaev.signatures.types import SignatureTypes  # type: ignore[import-untyped]
+from pyoaev.signatures.signature_type import SignatureType
 from src.collector.internals.oaev_uploaders import ExpectationUploader, TraceUploader
 from src.collector.models.exception import (
     CollectorEngineConfigError,
@@ -58,7 +58,7 @@ class BasicCollectorEngine:
         self.current_summary = ExpectationSummary()
         self.oaev_detection_helper = OpenAEVDetectionHelper(
             logger=self.logger,
-            relevant_signatures_types=self.source.signatures,
+            relevant_signatures_types=self.source.relevant_signatures_types,
         )
         self.expectation_uploader = ExpectationUploader(
             oaev_api=self.oaev_api,
@@ -77,12 +77,12 @@ class BasicCollectorEngine:
         return self.source.data_fetcher_model
 
     @property
-    def signatures(self) -> list[SignatureTypes]:
+    def signatures(self) -> list[SignatureType]:
         return self.source.signatures
 
     def configure_engine(self, config: SourceConfig) -> None:
         self.logger.info(
-            f"{LOG_PREFIX} Supported signatures: {[sig.value for sig in self.signatures]}"
+            f"{LOG_PREFIX} Supported signatures: {[sig.value for sig in self.source.relevant_signatures_types]}"
         )
         self.config = config
         self._reset_summary()
@@ -160,10 +160,11 @@ class BasicCollectorEngine:
         1. fetch the data using the data fetcher provided
         2. serialize each data as OAEVData
         3. group the expectation signatures per expectation
-        4. check for a match between the grouped signatures (3.) with the OAEVData (2.)
-        5. serialize each data as TraceData
-        6. check for a match between the expectation (0.) and the data (1.)
-        7. create the ExpectationResult using the previous match (6.) and the TraceData (5.)
+        4. transform the OAEVData into alert data using signature type matching metadata
+        5. check for a match between the grouped signatures (3.) with the alert data (4.)
+        6. serialize each data as TraceData
+        7. check for a match between the expectation (0.) and the data (1.)
+        8. create the ExpectationResult using the previous match (7.) and the TraceData (6.)
         then return a list of all the results produced from the batch
         """
         batch_results = []
@@ -214,18 +215,28 @@ class BasicCollectorEngine:
                         )
                     )
 
-                    # (4) match signature (3) with oaevdata (2)
-                    flag = self.source_handler.match_signature_groups_and_oaevdata(
-                        signature_groups,
+                    # (4) transform the oaev data into alert data
+                    alert_data = self.source_handler.get_alert_data_from_oaev_data(
+                        self.signatures,
                         oaev_data,
+                    )
+
+                    # (5) match expectation signature (3) with alert data (4)
+                    flag = self.source_handler.match_signature_groups_and_alert_data(
+                        signature_groups,
+                        alert_data,
                         self.oaev_detection_helper,
                     )
                     if flag:
-                        # (5) serialize data as tracedata
+                        self.logger.debug(
+                            f"{LOG_PREFIX} Match for expectation {expectation.inject_expectation_id}"
+                        )
+
+                        # (6) serialize data as tracedata
                         trace = self.source_handler.serialize_as_tracedata(element)
                         traces.append(trace.model_dump())
 
-                        # (6) match expectation (0) with sourcedata (1)
+                        # (7) match expectation (0) with sourcedata (1)
                         matchflag, breakflag = (
                             self.source_handler.match_expectation_and_sourcedata(
                                 expectation, element
@@ -236,7 +247,7 @@ class BasicCollectorEngine:
                         if breakflag:
                             break
 
-                # (7) create results from step 6 + tracedata (5)
+                # (8) create results from step 7 + tracedata (6)
                 result = ExpectationResult(
                     expectation_id=str(expectation.inject_expectation_id),
                     is_valid=matched,

--- a/microsoft-defender-o365/src/collector/models/source.py
+++ b/microsoft-defender-o365/src/collector/models/source.py
@@ -115,7 +115,6 @@ class SourceHandler(SourceHandlerProtocol):
         if not oaev_data:
             return alert_data
 
-        alert_data = {}
         for signature in signatures:
             sig_value = signature.label.value
             try:
@@ -135,7 +134,7 @@ class SourceHandler(SourceHandlerProtocol):
         """
         matching signatures extracted from an expectation and already filtered against source's signatures
         against the fetched data serialized in an OAEVData format turned into alert data
-        (signature types oriented formating turned matching oriented formating)
+        (signature types oriented formatting turned matching oriented formatting)
         """
         if not alert_data:
             return False

--- a/microsoft-defender-o365/src/collector/models/source.py
+++ b/microsoft-defender-o365/src/collector/models/source.py
@@ -1,15 +1,19 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, computed_field
 from pyoaev.apis.inject_expectation.model.expectation import (  # type: ignore[import-untyped]
     DetectionExpectation,
     PreventionExpectation,
 )
 from pyoaev.helpers import OpenAEVDetectionHelper  # type: ignore[import-untyped]
+from pyoaev.signatures.signature_type import (
+    SignatureType,  # type: ignore[import-untyped]
+)
 from pyoaev.signatures.types import SignatureTypes  # type: ignore[import-untyped]
 from src.collector.models.data import OAEVData, TraceData
 from src.collector.protocols.data_fetcher import DataFetcherProtocol, FetchParamsHook
 from src.collector.protocols.source_data import SourceDataProtocol
 from src.collector.protocols.source_handler import SourceHandlerProtocol
 from src.collector.types.collector import (
+    AlertData,
     ExpectationsList,
     SignatureGroups,
     SourceConfig,
@@ -24,9 +28,16 @@ class Source(BaseModel):
     - the list of signature types expected to eventually match the data
     """
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     data_fetcher_model: type[DataFetcherProtocol]  # or is it type[DataFetcherProtocol]?
     source_data_model: type[SourceDataProtocol]  # or is it type[SourceDataProtocol]?
-    signatures: list[SignatureTypes]
+    signatures: list[SignatureType]
+
+    @computed_field
+    @property
+    def relevant_signatures_types(self) -> list[SignatureTypes]:
+        return [signature.label for signature in self.signatures]
 
 
 class SourceHandler(SourceHandlerProtocol):
@@ -70,49 +81,78 @@ class SourceHandler(SourceHandlerProtocol):
 
     @staticmethod
     def get_expectation_signature_groups(
-        signatures: list[SignatureTypes],
+        signatures: list[SignatureType],
         expectation: DetectionExpectation | PreventionExpectation,
     ) -> SignatureGroups:
         """
         group the expectation's signatures according to the source provided signatures
         """
-        supported_types = {sig_type.value for sig_type in signatures}
+        supported_types = {sig.label for sig in signatures}
         signature_groups: SignatureGroups = {}
-        for sig in expectation.inject_expectation_signatures:
+        for expectation_sig in expectation.inject_expectation_signatures:
             # ignore unsupported signatures according to source
-            if sig.type.value not in supported_types:
+            if expectation_sig.type not in supported_types:
                 continue
             # ignore end_date signature type
-            if sig.type.value == "end_date":
+            if expectation_sig.type == SignatureTypes.SIG_TYPE_END_DATE:
                 continue
             # create or append to a list of dict-serialized signature data
-            signature_groups.setdefault(sig.type.value, []).append(
-                {"type": sig.type.value, "value": sig.value}
+            signature_groups.setdefault(expectation_sig.type.value, []).append(
+                {"type": expectation_sig.type.value, "value": expectation_sig.value}
             )
         return signature_groups
 
     @staticmethod
-    def match_signature_groups_and_oaevdata(
-        signature_groups: SignatureGroups,
+    def get_alert_data_from_oaev_data(
+        signatures: list[SignatureType],
         oaev_data: OAEVData,
+    ) -> AlertData:
+        """
+        Formatting the OAEVData into the expected matching format known as alert data in pyoaev,
+        based on the matching instructions provided in the SignatureType objects
+        """
+        alert_data: AlertData = {}
+        if not oaev_data:
+            return alert_data
+
+        alert_data = {}
+        for signature in signatures:
+            sig_value = signature.label.value
+            try:
+                value = getattr(oaev_data, sig_value)
+            except AttributeError:
+                pass
+            else:
+                alert_data[sig_value] = signature.make_struct_for_matching(value)
+        return alert_data
+
+    @staticmethod
+    def match_signature_groups_and_alert_data(
+        signature_groups: SignatureGroups,
+        alert_data: AlertData,
         oaev_detection_helper: OpenAEVDetectionHelper,
     ) -> bool:
         """
         matching signatures extracted from an expectation and already filtered against source's signatures
-        against the fetched data serialized in an OAEVData format (signature types oriented formating)
+        against the fetched data serialized in an OAEVData format turned into alert data
+        (signature types oriented formating turned matching oriented formating)
         """
-        if not oaev_data:
+        if not alert_data:
             return False
 
         for sig_type, signature_data in signature_groups.items():
-            try:
-                filtered_data = {sig_type: getattr(oaev_data, sig_type)}
-            except AttributeError:
+            if sig_type not in alert_data:
+                # if an expected signature type is not available in the alert data,
+                # then no need to use the matcher
                 return False
             match_result = oaev_detection_helper.match_alert_elements(
-                signature_data, filtered_data
+                signatures=signature_data,
+                alert_data={sig_type: alert_data[sig_type]},
             )
             if not match_result:
+                # since matching must be done on all provided signatures,
+                # cf. behavior of the helper in pyoaev,
+                # fail-fast as soon as one misses
                 return False
         return True
 

--- a/microsoft-defender-o365/src/collector/protocols/source_handler.py
+++ b/microsoft-defender-o365/src/collector/protocols/source_handler.py
@@ -5,11 +5,14 @@ from pyoaev.apis.inject_expectation.model.expectation import (  # type: ignore[i
     PreventionExpectation,
 )
 from pyoaev.helpers import OpenAEVDetectionHelper  # type: ignore[import-untyped]
-from pyoaev.signatures.types import SignatureTypes  # type: ignore[import-untyped]
+from pyoaev.signatures.signature_type import (
+    SignatureType,  # type: ignore[import-untyped]
+)
 from src.collector.models.data import OAEVData, TraceData
 from src.collector.protocols.data_fetcher import DataFetcherProtocol, FetchParamsHook
 from src.collector.protocols.source_data import SourceDataProtocol
 from src.collector.types.collector import (
+    AlertData,
     ExpectationsList,
     SignatureGroups,
     SourceConfig,
@@ -32,14 +35,20 @@ class SourceHandlerProtocol(Protocol):
 
     def get_expectation_signature_groups(
         self,
-        signatures: list[SignatureTypes],
+        signatures: list[SignatureType],
         expectation: DetectionExpectation | PreventionExpectation,
     ) -> SignatureGroups: ...
 
-    def match_signature_groups_and_oaevdata(
+    def get_alert_data_from_oaev_data(
+        self,
+        signatures: list[SignatureType],
+        oaev_data: OAEVData,
+    ) -> AlertData: ...
+
+    def match_signature_groups_and_alert_data(
         self,
         signature_groups: SignatureGroups,
-        oaev_data: OAEVData,
+        alert_data: AlertData,
         oaev_detection_helper: OpenAEVDetectionHelper,
     ) -> bool: ...
 

--- a/microsoft-defender-o365/src/collector/types/collector.py
+++ b/microsoft-defender-o365/src/collector/types/collector.py
@@ -9,3 +9,4 @@ from src.models.settings.source_configs import _ConfigLoaderSource
 SourceConfig: TypeAlias = _ConfigLoaderSource
 ExpectationsList: TypeAlias = Sequence[DetectionExpectation | PreventionExpectation]
 SignatureGroups: TypeAlias = dict[str, list[dict[str, str]]]
+AlertData: TypeAlias = dict[str, dict[str, str]]

--- a/microsoft-defender-o365/src/source/signatures.py
+++ b/microsoft-defender-o365/src/source/signatures.py
@@ -3,7 +3,7 @@ from pyoaev.signatures.types import (  # type: ignore[import-untyped]  # noqa: F
     SignatureTypes,
 )
 
-SUPPORTED_SIGNATURES: list[SignatureTypes] = [
+SUPPORTED_SIGNATURES: list[SignatureType] = [
     SignatureType(SignatureTypes.SIG_TYPE_START_DATE),
     SignatureType(SignatureTypes.SIG_TYPE_END_DATE),
     SignatureType(SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME),

--- a/microsoft-defender-o365/src/source/signatures.py
+++ b/microsoft-defender-o365/src/source/signatures.py
@@ -1,14 +1,15 @@
+from pyoaev.signatures.signature_type import SignatureType
 from pyoaev.signatures.types import (  # type: ignore[import-untyped]  # noqa: F401
     SignatureTypes,
 )
 
 SUPPORTED_SIGNATURES: list[SignatureTypes] = [
-    SignatureTypes.SIG_TYPE_START_DATE,
-    SignatureTypes.SIG_TYPE_END_DATE,
-    SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME,
-    SignatureTypes.SIG_TYPE_URL_HASH,
-    SignatureTypes.SIG_TYPE_FILE_HASH,
-    SignatureTypes.SIG_TYPE_SOURCE_EMAIL,
-    SignatureTypes.SIG_TYPE_TARGET_EMAIL,
-    SignatureTypes.SIG_TYPE_EMAIL_CUSTOM_HEADER,
+    SignatureType(SignatureTypes.SIG_TYPE_START_DATE),
+    SignatureType(SignatureTypes.SIG_TYPE_END_DATE),
+    SignatureType(SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME),
+    SignatureType(SignatureTypes.SIG_TYPE_URL_HASH),
+    SignatureType(SignatureTypes.SIG_TYPE_FILE_HASH),
+    SignatureType(SignatureTypes.SIG_TYPE_SOURCE_EMAIL),
+    SignatureType(SignatureTypes.SIG_TYPE_TARGET_EMAIL),
+    SignatureType(SignatureTypes.SIG_TYPE_EMAIL_CUSTOM_HEADER),
 ]

--- a/microsoft-defender-o365/tests/conftest.py
+++ b/microsoft-defender-o365/tests/conftest.py
@@ -352,7 +352,7 @@ def _given_microsoft_defender_o365_stubbed_source_handler(
     Args:
         stub_return_get_source_data: Value returned by ``get_source_data``.
         stub_return_match_groups: Value returned by
-            ``match_signature_groups_and_oaevdata``.
+            ``match_signature_groups_and_alert_data``.
         stub_return_match_expectation: Value returned by
             ``match_expectation_and_sourcedata``.
 
@@ -371,7 +371,7 @@ def _given_microsoft_defender_o365_stubbed_source_handler(
     source_handler.get_source_data.return_value = stub_return_get_source_data
     source_handler.serialize_as_oaevdata.return_value = MagicMock()
     source_handler.get_expectation_signature_groups.return_value = {}
-    source_handler.match_signature_groups_and_oaevdata.return_value = (
+    source_handler.match_signature_groups_and_alert_data.return_value = (
         stub_return_match_groups
     )
     source_handler.serialize_as_tracedata.return_value.model_dump.return_value = {
@@ -1022,7 +1022,7 @@ def _given_detection_expectation_with_supported_sigs(
         inject_expectation_id=uuid.uuid4(),
         inject_expectation_signatures=[
             ExpectationSignature(
-                type=sig_type,
+                type=sig_type.label,
                 value=_sig_test_value_for_type(sig_type),
             )
             for sig_type in SUPPORTED_SIGNATURES
@@ -1045,7 +1045,7 @@ def _given_prevention_expectation_with_supported_sigs() -> PreventionExpectation
         inject_expectation_id=uuid.uuid4(),
         inject_expectation_signatures=[
             ExpectationSignature(
-                type=sig_type,
+                type=sig_type.label,
                 value=_sig_test_value_for_type(sig_type),
             )
             for sig_type in SUPPORTED_SIGNATURES
@@ -1074,7 +1074,9 @@ def _given_expectation_with_unsupported_sigs() -> DetectionExpectation:
     extra_types = [t for t in all_types if t not in SUPPORTED_SIGNATURES][:2]
 
     sigs = [
-        ExpectationSignature(type=sig_type, value=_sig_test_value_for_type(sig_type))
+        ExpectationSignature(
+            type=sig_type.label, value=_sig_test_value_for_type(sig_type.label)
+        )
         for sig_type in SUPPORTED_SIGNATURES
     ] + [ExpectationSignature(type=t, value="unsupported-value") for t in extra_types]
 
@@ -1152,7 +1154,7 @@ def _given_matching_alert_data(
     }
     oaev_data.model_dump.return_value = sig_values
     for sig_type in SUPPORTED_SIGNATURES:
-        setattr(oaev_data, sig_type.value, sig_values[sig_type.value])
+        setattr(oaev_data, sig_type.label.value, sig_values[sig_type.label.value])
 
     # Detection / prevention flags
     mock_sd.is_detected.return_value = not prevention
@@ -1228,7 +1230,7 @@ def _given_non_matching_alert_data() -> list:
     }
     oaev_data.model_dump.return_value = sig_values
     for sig_type in SUPPORTED_SIGNATURES:
-        setattr(oaev_data, sig_type.value, sig_values[sig_type.value])
+        setattr(oaev_data, sig_type.label.value, sig_values[sig_type.label.value])
 
     mock_sd.is_detected.return_value = True
     mock_sd.is_prevented.return_value = False
@@ -1319,8 +1321,8 @@ def _when_engine_processes_batch(
     mock_handler.get_expectation_signature_groups = (
         SourceHandler.get_expectation_signature_groups
     )
-    mock_handler.match_signature_groups_and_oaevdata = (
-        SourceHandler.match_signature_groups_and_oaevdata
+    mock_handler.match_signature_groups_and_alert_data = (
+        SourceHandler.match_signature_groups_and_alert_data
     )
     mock_handler.serialize_as_tracedata = SourceHandler.serialize_as_tracedata
     mock_handler.match_expectation_and_sourcedata = (
@@ -1422,7 +1424,7 @@ def _then_only_supported_sigs_retained(sig_groups: dict) -> None:
     """
     from src.source.signatures import SUPPORTED_SIGNATURES
 
-    supported_values = {sig.value for sig in SUPPORTED_SIGNATURES}
+    supported_values = {sig.label.value for sig in SUPPORTED_SIGNATURES}
     for sig_type_key in sig_groups:
         assert (
             sig_type_key in supported_values

--- a/microsoft-defender-o365/tests/conftest.py
+++ b/microsoft-defender-o365/tests/conftest.py
@@ -1321,6 +1321,9 @@ def _when_engine_processes_batch(
     mock_handler.get_expectation_signature_groups = (
         SourceHandler.get_expectation_signature_groups
     )
+    mock_handler.get_alert_data_from_oaev_data = (
+        SourceHandler.get_alert_data_from_oaev_data
+    )
     mock_handler.match_signature_groups_and_alert_data = (
         SourceHandler.match_signature_groups_and_alert_data
     )

--- a/microsoft-defender-o365/tests/conftest.py
+++ b/microsoft-defender-o365/tests/conftest.py
@@ -1075,7 +1075,7 @@ def _given_expectation_with_unsupported_sigs() -> DetectionExpectation:
 
     sigs = [
         ExpectationSignature(
-            type=sig_type.label, value=_sig_test_value_for_type(sig_type.label)
+            type=sig_type.label, value=_sig_test_value_for_type(sig_type)
         )
         for sig_type in SUPPORTED_SIGNATURES
     ] + [ExpectationSignature(type=t, value="unsupported-value") for t in extra_types]
@@ -1108,56 +1108,29 @@ def _given_matching_alert_data(
     from src.source.signatures import SUPPORTED_SIGNATURES
 
     mock_sd = MagicMock()
-    oaev_data = MagicMock()
 
-    # to_oaev_data returns an OAEVData-like object with matching values
-    def to_oaev_data():
-        return oaev_data
-
-    mock_sd.to_oaev_data = to_oaev_data
-
-    # Set attribute access to return matching values in the structure
-    # expected by OpenAEVDetectionHelper.match_alert_elements
     sig_values = {
-        SignatureTypes.SIG_TYPE_SOURCE_EMAIL.value: {
-            "type": "simple",
-            "data": ["bad@evil.com"],
-        },
-        SignatureTypes.SIG_TYPE_TARGET_EMAIL.value: {
-            "type": "simple",
-            "data": ["victim@corp.com"],
-        },
-        SignatureTypes.SIG_TYPE_URL_HASH.value: {
-            "type": "simple",
-            "data": ["6e828dac1a6b547942ad393d0e3b5e37e50e974a86c8c61e5b77e6a0c7b7c6d"],
-        },
-        SignatureTypes.SIG_TYPE_FILE_HASH.value: {
-            "type": "simple",
-            "data": ["abc123"],
-        },
-        SignatureTypes.SIG_TYPE_EMAIL_CUSTOM_HEADER.value: {
-            "type": "simple",
-            "data": ["header-val"],
-        },
-        SignatureTypes.SIG_TYPE_START_DATE.value: {
-            "type": "simple",
-            "data": ["this.is.a.date"],
-        },
-        SignatureTypes.SIG_TYPE_END_DATE.value: {
-            "type": "simple",
-            "data": ["this.is.a.date"],
-        },
-        SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME.value: {
-            "type": "simple",
-            "data": ["parent/process.name"],
-        },
+        SignatureTypes.SIG_TYPE_SOURCE_EMAIL.value: ["bad@evil.com"],
+        SignatureTypes.SIG_TYPE_TARGET_EMAIL.value: ["victim@corp.com"],
+        SignatureTypes.SIG_TYPE_URL_HASH.value: [
+            "6e828dac1a6b547942ad393d0e3b5e37e50e974a86c8c61e5b77e6a0c7b7c6d"
+        ],
+        SignatureTypes.SIG_TYPE_FILE_HASH.value: ["abc123"],
+        SignatureTypes.SIG_TYPE_EMAIL_CUSTOM_HEADER.value: ["header-val"],
+        SignatureTypes.SIG_TYPE_START_DATE.value: ["this.is.a.date"],
+        SignatureTypes.SIG_TYPE_END_DATE.value: ["this.is.a.date"],
+        SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME.value: ["parent/process.name"],
     }
+
+    oaev_data = MagicMock()
     oaev_data.model_dump.return_value = sig_values
     for sig_type in SUPPORTED_SIGNATURES:
         setattr(oaev_data, sig_type.label.value, sig_values[sig_type.label.value])
 
+    mock_sd.to_oaev_data.return_value = oaev_data
+
     # Detection / prevention flags
-    mock_sd.is_detected.return_value = not prevention
+    mock_sd.is_detected.return_value = True
     mock_sd.is_prevented.return_value = prevention
 
     # Trace data serialization
@@ -1184,53 +1157,25 @@ def _given_non_matching_alert_data() -> list:
     from src.source.signatures import SUPPORTED_SIGNATURES
 
     mock_sd = MagicMock()
-    oaev_data = MagicMock()
-
-    def to_oaev_data():
-        return oaev_data
-
-    mock_sd.to_oaev_data = to_oaev_data
 
     # Values that won't match expectation signatures
     sig_values = {
-        SignatureTypes.SIG_TYPE_SOURCE_EMAIL.value: {
-            "type": "simple",
-            "data": ["other@evil.com"],
-        },
-        SignatureTypes.SIG_TYPE_TARGET_EMAIL.value: {
-            "type": "simple",
-            "data": ["boss@corp.com"],
-        },
-        SignatureTypes.SIG_TYPE_URL_HASH.value: {
-            "type": "simple",
-            "data": [
-                "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-            ],
-        },
-        SignatureTypes.SIG_TYPE_FILE_HASH.value: {
-            "type": "simple",
-            "data": ["xyz789"],
-        },
-        SignatureTypes.SIG_TYPE_EMAIL_CUSTOM_HEADER.value: {
-            "type": "simple",
-            "data": ["other-header"],
-        },
-        SignatureTypes.SIG_TYPE_START_DATE.value: {
-            "type": "simple",
-            "data": ["this.is.a.date"],
-        },
-        SignatureTypes.SIG_TYPE_END_DATE.value: {
-            "type": "simple",
-            "data": ["this.is.a.date"],
-        },
-        SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME.value: {
-            "type": "simple",
-            "data": ["parent/process.name"],
-        },
+        SignatureTypes.SIG_TYPE_SOURCE_EMAIL.value: ["other@evil.com"],
+        SignatureTypes.SIG_TYPE_TARGET_EMAIL.value: ["boss@corp.com"],
+        SignatureTypes.SIG_TYPE_URL_HASH.value: [
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        ],
+        SignatureTypes.SIG_TYPE_FILE_HASH.value: ["xyz789"],
+        SignatureTypes.SIG_TYPE_EMAIL_CUSTOM_HEADER.value: ["other-header"],
+        SignatureTypes.SIG_TYPE_START_DATE.value: ["this.is.a.date"],
+        SignatureTypes.SIG_TYPE_END_DATE.value: ["this.is.a.date"],
+        SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME.value: ["parent/process.name"],
     }
+    oaev_data = MagicMock()
     oaev_data.model_dump.return_value = sig_values
     for sig_type in SUPPORTED_SIGNATURES:
         setattr(oaev_data, sig_type.label.value, sig_values[sig_type.label.value])
+    mock_sd.to_oaev_data.return_value = oaev_data
 
     mock_sd.is_detected.return_value = True
     mock_sd.is_prevented.return_value = False
@@ -1264,7 +1209,7 @@ def _given_fetched_data_error() -> None:
 
 def _when_engine_processes_batch(
     expectations: list,
-    alert_data: list,
+    source_data: list,
 ) -> list:
     """When the engine processes the batch.
 
@@ -1273,7 +1218,7 @@ def _when_engine_processes_batch(
 
     Args:
         expectations: List of expectation objects to process.
-        alert_data: List of source data objects (mocked).
+        source_data: List of source data objects (mocked).
 
     Returns:
         List of ExpectationResult objects.
@@ -1290,17 +1235,14 @@ def _when_engine_processes_batch(
             _CHUNK8_STATE["fetch_error"],
         ]  # trigger error path
     else:
-        data = alert_data if alert_data else _CHUNK8_STATE.get("fetch_result", [])
-
-    # Build signature groups for matching
-    SourceHandler.get_expectation_signature_groups(
-        SUPPORTED_SIGNATURES, expectations[0]
-    )
+        data = source_data if source_data else _CHUNK8_STATE.get("fetch_result", [])
 
     # Detection helper that matches based on sig groups
     OpenAEVDetectionHelper(
         logger=MagicMock(),
-        relevant_signatures_types=SUPPORTED_SIGNATURES,
+        relevant_signatures_types=[
+            signature.label for signature in SUPPORTED_SIGNATURES
+        ],
     )
 
     # Mock the source handler to inject our data
@@ -1320,6 +1262,9 @@ def _when_engine_processes_batch(
     mock_handler.serialize_as_oaevdata = SourceHandler.serialize_as_oaevdata
     mock_handler.get_expectation_signature_groups = (
         SourceHandler.get_expectation_signature_groups
+    )
+    mock_handler.get_alert_data_from_oaev_data = (
+        SourceHandler.get_alert_data_from_oaev_data
     )
     mock_handler.match_signature_groups_and_alert_data = (
         SourceHandler.match_signature_groups_and_alert_data
@@ -1481,4 +1426,4 @@ def _sig_test_value_for_type(sig_type) -> str:
         SignatureTypes.SIG_TYPE_END_DATE: "this.is.a.date",
         SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME: "parent/process.name",
     }
-    return VALUES.get(sig_type, "test-value")
+    return VALUES.get(sig_type.label, "test-value")

--- a/microsoft-defender-o365/tests/features/test_collector_main_loop.py
+++ b/microsoft-defender-o365/tests/features/test_collector_main_loop.py
@@ -44,7 +44,7 @@ def test_collector_loop_completes_a_full_cycle_with_stubs(
 ) -> None:
     """Scenario Outline: Collector loop completes a full cycle with stubs"""
     # Given: CHK.1 scaffold is in place, CHK.2 DefenderO365Config is defined,
-    # DataFetcher/OpenAEV API/match_signature_groups_and_oaevdata are stubbed,
+    # DataFetcher/OpenAEV API/match_signature_groups_and_alert_data are stubbed,
     # Source is declared, and a DefenderO365Collector(BaseCollector) instance
     # with all methods stubbed is built
     source = _given_microsoft_defender_o365_source_declared()
@@ -70,7 +70,7 @@ def test_collector_loop_completes_a_full_cycle_with_stubs(
     _then_get_source_data_is_called_exactly_once(source_handler)
     _then_serialize_as_oaevdata_is_called_exactly_once(source_handler)
     _then_get_expectation_signature_groups_is_called_exactly_once(source_handler)
-    _then_match_signature_groups_and_oaevdata_is_called_exactly_once(source_handler)
+    _then_match_signature_groups_and_alert_data_is_called_exactly_once(source_handler)
     _then_match_expectation_and_sourcedata_is_called_exactly_once(source_handler)
     _then_serialize_as_tracedata_is_called_exactly_once(source_handler)
     _then_microsoft_defender_o365_no_unhandled_exception_raised(error)
@@ -321,16 +321,16 @@ def _then_get_expectation_signature_groups_is_called_exactly_once(
     source_handler.get_expectation_signature_groups.assert_called_once()
 
 
-def _then_match_signature_groups_and_oaevdata_is_called_exactly_once(
+def _then_match_signature_groups_and_alert_data_is_called_exactly_once(
     source_handler: MagicMock,
 ) -> None:
-    """Then match_signature_groups_and_oaevdata is called exactly once.
+    """Then match_signature_groups_and_alert_data is called exactly once.
 
     Args:
         source_handler: The stubbed source handler used by the engine.
 
     """
-    source_handler.match_signature_groups_and_oaevdata.assert_called_once()
+    source_handler.match_signature_groups_and_alert_data.assert_called_once()
 
 
 def _then_match_expectation_and_sourcedata_is_called_exactly_once(

--- a/microsoft-defender-o365/tests/unit/source/test_signatures.py
+++ b/microsoft-defender-o365/tests/unit/source/test_signatures.py
@@ -12,7 +12,7 @@ class TestSignatures(unittest.TestCase):
 
     def test_types(self):
         for sig in module.SUPPORTED_SIGNATURES:
-            self.assertIsInstance(sig, module.SignatureTypes)
+            self.assertIsInstance(sig, module.SignatureType)
 
     def test_no_duplicate(self):
         for sig in module.SUPPORTED_SIGNATURES:

--- a/template/src/collector/collector.py
+++ b/template/src/collector/collector.py
@@ -1,6 +1,6 @@
 import logging
 
-from pyoaev.daemons import CollectorDaemon
+from pyoaev.daemons import CollectorDaemon  # type: ignore[import-untyped]
 from slugify import slugify
 from src.collector.engines.basic import BasicCollectorEngine
 from src.collector.models.exception import (
@@ -19,11 +19,13 @@ from src.models.settings.config_loader import ConfigLoader
 LOG_PREFIX = "[Collector]"
 
 
-class BaseCollector(CollectorDaemon):
+class BaseCollector(CollectorDaemon):  # type: ignore[misc]
     """
     Generic BaseCollector providing a defined source to a generic collector engine.
     This collector is use-case agnostic and works with any source provided.
     """
+
+    logger: logging.Logger
 
     def __init__(
         self,
@@ -45,7 +47,7 @@ class BaseCollector(CollectorDaemon):
 
             super().__init__(
                 configuration=self.config.to_daemon_config(),
-                collector_type=f"openaev_{slugify(self.name, separator="_")}",
+                collector_type=f"openaev_{slugify(self.name, separator='_')}",
             )
 
             self.logger.info(

--- a/template/src/collector/engines/basic.py
+++ b/template/src/collector/engines/basic.py
@@ -1,13 +1,13 @@
 import logging
 import os
 
-from pyoaev.apis.inject_expectation.model import (
+from pyoaev.apis.inject_expectation.model import (  # type: ignore[import-untyped]
     DetectionExpectation,
     PreventionExpectation,
 )
-from pyoaev.client import OpenAEV
-from pyoaev.helpers import OpenAEVDetectionHelper
-from pyoaev.signatures.types import SignatureTypes
+from pyoaev.client import OpenAEV  # type: ignore[import-untyped]
+from pyoaev.helpers import OpenAEVDetectionHelper  # type: ignore[import-untyped]
+from pyoaev.signatures.signature_type import SignatureType
 from src.collector.internals.oaev_uploaders import ExpectationUploader, TraceUploader
 from src.collector.models.exception import (
     CollectorEngineConfigError,
@@ -62,7 +62,7 @@ class BasicCollectorEngine:
         self.current_summary = ExpectationSummary()
         self.oaev_detection_helper = OpenAEVDetectionHelper(
             logger=self.logger,
-            relevant_signatures_types=self.source.signatures,
+            relevant_signatures_types=self.source.relevant_signatures_types,
         )
         self.expectation_uploader = ExpectationUploader(
             oaev_api=self.oaev_api,
@@ -81,12 +81,12 @@ class BasicCollectorEngine:
         return self.source.data_fetcher_model
 
     @property
-    def signatures(self) -> list[SignatureTypes]:
+    def signatures(self) -> list[SignatureType]:
         return self.source.signatures
 
     def configure_engine(self, config: SourceConfig, batching: bool = False) -> None:
         self.logger.info(
-            f"{LOG_PREFIX} Supported signatures: {[sig.value for sig in self.signatures]}"
+            f"{LOG_PREFIX} Supported signatures: {[sig.value for sig in self.source.relevant_signatures_types]}"
         )
         self.config = config
         self.batching = batching
@@ -213,13 +213,17 @@ class BasicCollectorEngine:
                         )
                     )
 
-                    # (4) match signature (3) with oaevdata (2)
+                    # (4) match expectation signature (3) with oaevdata (2) according to signatures
                     flag = self.source_handler.match_signature_groups_and_oaevdata(
                         signature_groups,
                         oaev_data,
                         self.oaev_detection_helper,
+                        self.signatures,
                     )
                     if flag:
+                        self.logger.info(
+                            f"{LOG_PREFIX} Match for expectation {expectation.inject_expectation_id}"
+                        )
                         # (5) serialize data as tracedata
                         trace = self.source_handler.serialize_as_tracedata(element)
                         traces.append(trace.model_dump())

--- a/template/src/collector/engines/basic.py
+++ b/template/src/collector/engines/basic.py
@@ -165,10 +165,11 @@ class BasicCollectorEngine:
         1. fetch the data using the data fetcher provided
         2. serialize each data as OAEVData
         3. group the expectation signatures per expectation
-        4. check for a match between the grouped signatures (3.) with the OAEVData (2.)
-        5. serialize each data as TraceData
-        6. check for a match between the expectation (0.) and the data (1.)
-        7. create the ExpectationResult using the previous match (6.) and the TraceData (5.)
+        4. transform the OAEVData into alert data using signature type matching metadata
+        5. check for a match between the grouped signatures (3.) with the alert data (4.)
+        6. serialize each data as TraceData
+        7. check for a match between the expectation (0.) and the data (1.)
+        8. create the ExpectationResult using the previous match (7.) and the TraceData (6.)
         then return a list of all the results produced from the batch
         """
         batch_results = []
@@ -213,22 +214,27 @@ class BasicCollectorEngine:
                         )
                     )
 
-                    # (4) match expectation signature (3) with oaevdata (2) according to signatures
-                    flag = self.source_handler.match_signature_groups_and_oaevdata(
-                        signature_groups,
-                        oaev_data,
-                        self.oaev_detection_helper,
+                    # (4) transform the oaev data into alert data
+                    alert_data = self.source_handler.get_alert_data_from_oaev_data(
                         self.signatures,
+                        oaev_data,
+                    )
+
+                    # (5) match expectation signatures (3) with alert data (4)
+                    flag = self.source_handler.match_signature_groups_and_alert_data(
+                        signature_groups,
+                        alert_data,
+                        self.oaev_detection_helper,
                     )
                     if flag:
                         self.logger.info(
                             f"{LOG_PREFIX} Match for expectation {expectation.inject_expectation_id}"
                         )
-                        # (5) serialize data as tracedata
+                        # (6) serialize data as tracedata
                         trace = self.source_handler.serialize_as_tracedata(element)
                         traces.append(trace.model_dump())
 
-                        # (6) match expectation (0) with sourcedata (1)
+                        # (7) match expectation (0) with sourcedata (1)
                         matchflag, breakflag = (
                             self.source_handler.match_expectation_and_sourcedata(
                                 expectation, element
@@ -239,7 +245,7 @@ class BasicCollectorEngine:
                         if breakflag:
                             break
 
-                # (7) create results from step 6 + tracedata (5)
+                # (8) create results from step 7 + tracedata (6)
                 result = ExpectationResult(
                     expectation_id=str(expectation.inject_expectation_id),
                     is_valid=matched,

--- a/template/src/collector/engines/basic.py
+++ b/template/src/collector/engines/basic.py
@@ -227,7 +227,7 @@ class BasicCollectorEngine:
                         self.oaev_detection_helper,
                     )
                     if flag:
-                        self.logger.info(
+                        self.logger.debug(
                             f"{LOG_PREFIX} Match for expectation {expectation.inject_expectation_id}"
                         )
                         # (6) serialize data as tracedata

--- a/template/src/collector/internals/oaev_uploaders.py
+++ b/template/src/collector/internals/oaev_uploaders.py
@@ -1,8 +1,8 @@
 """Expectation uploader and expectation trace uploader based on the ResilientUploader object"""
 
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping, Sequence, cast
 
-from pyoaev.client import OpenAEV
+from pyoaev.client import OpenAEV  # type: ignore[import-untyped]
 from src.collector.internals.resilient_uploader import ResilientUploader
 from src.collector.models.expectations import ExpectationTrace
 from src.collector.types.internals import BulkData
@@ -70,7 +70,8 @@ class ExpectationUploader(ResilientUploader):
     @staticmethod
     def expectation_unpack_bulk_data(bulk_data: BulkData) -> Iterable[tuple[str, Any]]:
         """unpack the default expectation bulk data format into a (index,data) iterable"""
-        return bulk_data.items()
+        expectation_data = cast(Mapping[str, Any], bulk_data)
+        return expectation_data.items()
 
     def expectation_individual_upload(
         self, expectation_id: str, expectation_data: Any
@@ -132,8 +133,11 @@ class TraceUploader(ResilientUploader):
 
     def trace_bulk_upload(self, traces: BulkData) -> None:
         """expectation trace bulk upload using the OpenAEV API"""
+        trace_models = cast(Sequence[ExpectationTrace], traces)
         self.oaev_api.inject_expectation_trace.bulk_create(
-            payload={"expectation_traces": [trace.to_api_dict() for trace in traces]}
+            payload={
+                "expectation_traces": [trace.to_api_dict() for trace in trace_models]
+            }
         )
 
     @staticmethod

--- a/template/src/collector/models/data.py
+++ b/template/src/collector/models/data.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime
 from typing import Any, ClassVar
 
 from pydantic import AnyUrl, BaseModel, Field, model_validator
-from pyoaev.signatures.types import SignatureTypes
+from pyoaev.signatures.types import SignatureTypes  # type: ignore[import-untyped]
 
 
 class OAEVData(BaseModel, extra="allow"):
@@ -11,7 +11,7 @@ class OAEVData(BaseModel, extra="allow"):
     Apart from context, the allowed fields are signature types (e.g. parent_process_name)
     """
 
-    __pydantic_extra__: dict[str, str] = Field(default_factory=dict)
+    __pydantic_extra__: dict[str, str | list[str]] = Field(default_factory=dict)
     _allowed_values: ClassVar[frozenset[str]] = frozenset(
         [sig.value for sig in SignatureTypes]
     )

--- a/template/src/collector/models/expectations.py
+++ b/template/src/collector/models/expectations.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
-from pyoaev.apis.inject_expectation.model import (
+from pyoaev.apis.inject_expectation.model import (  # type: ignore[import-untyped]
     DetectionExpectation,
     PreventionExpectation,
 )

--- a/template/src/collector/models/source.py
+++ b/template/src/collector/models/source.py
@@ -129,7 +129,7 @@ class SourceHandler(SourceHandlerProtocol):
         """
         matching signatures extracted from an expectation and already filtered against source's signatures
         against the fetched data serialized in an OAEVData format turned into alert data
-        (signature types oriented formating turned matching oriented formating)
+        (signature types oriented formatting turned matching oriented formatting)
         """
         if not alert_data:
             return False

--- a/template/src/collector/models/source.py
+++ b/template/src/collector/models/source.py
@@ -1,15 +1,21 @@
-from pydantic import BaseModel
-from pyoaev.apis.inject_expectation.model.expectation import (
+from pydantic import BaseModel, ConfigDict, computed_field
+from pyoaev.apis.inject_expectation.model.expectation import (  # type: ignore[import-untyped]
     DetectionExpectation,
     PreventionExpectation,
 )
-from pyoaev.helpers import OpenAEVDetectionHelper
-from pyoaev.signatures.types import SignatureTypes
+from pyoaev.helpers import OpenAEVDetectionHelper  # type: ignore[import-untyped]
+from pyoaev.signatures.signature_type import SignatureType
+from pyoaev.signatures.types import (  # type: ignore[import-untyped]  # noqa: F401
+    SignatureTypes,
+)
 from src.collector.models.data import OAEVData, TraceData
 from src.collector.protocols.data_fetcher import DataFetcherProtocol
 from src.collector.protocols.source_data import SourceDataProtocol
 from src.collector.protocols.source_handler import SourceHandlerProtocol
-from src.collector.types.collector import SignatureGroups, SourceConfig
+from src.collector.types.collector import (
+    SignatureGroups,
+    SourceConfig,
+)
 
 
 class Source(BaseModel):
@@ -20,9 +26,16 @@ class Source(BaseModel):
     - the list of signature types expected to eventually match the data
     """
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     data_fetcher_model: type[DataFetcherProtocol]  # or is it type[DataFetcherProtocol]?
     source_data_model: type[SourceDataProtocol]  # or is it type[SourceDataProtocol]?
-    signatures: list[SignatureTypes]
+    signatures: list[SignatureType]
+
+    @computed_field
+    @property
+    def relevant_signatures_types(self) -> list[SignatureTypes]:
+        return [signature.label for signature in self.signatures]
 
 
 class SourceHandler(SourceHandlerProtocol):
@@ -62,24 +75,24 @@ class SourceHandler(SourceHandlerProtocol):
 
     @staticmethod
     def get_expectation_signature_groups(
-        signatures: list[SignatureTypes],
+        signatures: list[SignatureType],
         expectation: DetectionExpectation | PreventionExpectation,
     ) -> SignatureGroups:
         """
         group the expectation's signatures according to the source provided signatures
         """
-        supported_types = {sig_type.value for sig_type in signatures}
-        signature_groups: SignatureGroups = {}
-        for sig in expectation.inject_expectation_signatures:
+        supported_types = {sig.label for sig in signatures}
+        signature_groups: SignatureGroups = []
+        for expectation_sig in expectation.inject_expectation_signatures:
             # ignore unsupported signatures according to source
-            if sig.type.value not in supported_types:
+            if expectation_sig.type not in supported_types:
                 continue
             # ignore end_date signature type
-            if sig.type.value == "end_date":
+            if expectation_sig.type == SignatureTypes.SIG_TYPE_END_DATE:
                 continue
             # create or append to a list of dict-serialized signature data
-            signature_groups.setdefault(sig.type.value, []).append(
-                {"type": sig.type.value, "value": sig.value}
+            signature_groups.append(
+                {"type": expectation_sig.type.value, "value": expectation_sig.value}
             )
         return signature_groups
 
@@ -88,6 +101,7 @@ class SourceHandler(SourceHandlerProtocol):
         signature_groups: SignatureGroups,
         oaev_data: OAEVData,
         oaev_detection_helper: OpenAEVDetectionHelper,
+        signatures: list[SignatureType],
     ) -> bool:
         """
         matching signatures extracted from an expectation and already filtered against source's signatures
@@ -96,17 +110,45 @@ class SourceHandler(SourceHandlerProtocol):
         if not oaev_data:
             return False
 
-        for sig_type, signature_data in signature_groups.items():
+        alert_data = {}
+        for signature in signatures:
+            sig_value = signature.label.value
             try:
-                filtered_data = {sig_type: getattr(oaev_data, sig_type)}
+                value = getattr(oaev_data, sig_value)
             except AttributeError:
-                return False
-            match_result = oaev_detection_helper.match_alert_elements(
-                signature_data, filtered_data
-            )
-            if not match_result:
-                return False
-        return True
+                pass
+            else:
+                alert_data[sig_value] = signature.make_struct_for_matching(value)
+
+        if not alert_data:
+            return False
+
+        available_expectation_signatures = set(sig["type"] for sig in signature_groups)
+        available_alert_signatures = set(sig for sig in alert_data)
+        available_signatures = available_expectation_signatures.intersection(
+            available_alert_signatures
+        )
+        signature_groups = [
+            element
+            for element in signature_groups
+            if element["type"] in available_signatures
+        ]
+        if not signature_groups:
+            return False
+
+        alert_data = {
+            key: value
+            for key, value in alert_data.items()
+            if key in available_signatures
+        }
+        if not alert_data:
+            return False
+
+        match_result = oaev_detection_helper.match_alert_elements(
+            signatures=signature_groups,
+            alert_data=alert_data,
+        )
+        return match_result
 
     @staticmethod
     def serialize_as_tracedata(data: SourceDataProtocol) -> TraceData:

--- a/template/src/collector/models/source.py
+++ b/template/src/collector/models/source.py
@@ -13,6 +13,7 @@ from src.collector.protocols.data_fetcher import DataFetcherProtocol
 from src.collector.protocols.source_data import SourceDataProtocol
 from src.collector.protocols.source_handler import SourceHandlerProtocol
 from src.collector.types.collector import (
+    AlertData,
     SignatureGroups,
     SourceConfig,
 )
@@ -97,30 +98,39 @@ class SourceHandler(SourceHandlerProtocol):
         return signature_groups
 
     @staticmethod
-    def match_signature_groups_and_oaevdata(
-        signature_groups: SignatureGroups,
-        oaev_data: OAEVData,
-        oaev_detection_helper: OpenAEVDetectionHelper,
+    def get_alert_data_from_oaev_data(
         signatures: list[SignatureType],
+        oaev_data: OAEVData,
+    ) -> AlertData:
+        """
+        Formatting the OAEVData into the expected matching format known as alert data in pyoaev,
+        based on the matching instructions provided in the SignatureType objects
+        """
+        alert_data: AlertData = {}
+        if not oaev_data:
+            return alert_data
+
+        for signature in signatures:
+            sig_value = signature.label.value
+            try:
+                value = getattr(oaev_data, sig_value)
+            except AttributeError:
+                pass
+            else:
+                alert_data[sig_value] = signature.make_struct_for_matching(value)
+        return alert_data
+
+    @staticmethod
+    def match_signature_groups_and_alert_data(
+        signature_groups: SignatureGroups,
+        alert_data: AlertData,
+        oaev_detection_helper: OpenAEVDetectionHelper,
     ) -> bool:
         """
         matching signatures extracted from an expectation and already filtered against source's signatures
-        against the fetched data serialized in an OAEVData format (signature types oriented formating)
+        against the fetched data serialized in an OAEVData format turned into alert data
+        (signature types oriented formating turned matching oriented formating)
         """
-        if not oaev_data:
-            return False
-
-        alert_data = {}
-        for signature in signatures:
-            sig_value = signature.label.value
-            if sig_value in signature_groups:
-                try:
-                    value = getattr(oaev_data, sig_value)
-                except AttributeError:
-                    pass
-                else:
-                    alert_data[sig_value] = signature.make_struct_for_matching(value)
-
         if not alert_data:
             return False
 

--- a/template/src/collector/models/source.py
+++ b/template/src/collector/models/source.py
@@ -82,7 +82,7 @@ class SourceHandler(SourceHandlerProtocol):
         group the expectation's signatures according to the source provided signatures
         """
         supported_types = {sig.label for sig in signatures}
-        signature_groups: SignatureGroups = []
+        signature_groups: SignatureGroups = {}
         for expectation_sig in expectation.inject_expectation_signatures:
             # ignore unsupported signatures according to source
             if expectation_sig.type not in supported_types:
@@ -91,7 +91,7 @@ class SourceHandler(SourceHandlerProtocol):
             if expectation_sig.type == SignatureTypes.SIG_TYPE_END_DATE:
                 continue
             # create or append to a list of dict-serialized signature data
-            signature_groups.append(
+            signature_groups.setdefault(expectation_sig.type.value, []).append(
                 {"type": expectation_sig.type.value, "value": expectation_sig.value}
             )
         return signature_groups
@@ -113,42 +113,32 @@ class SourceHandler(SourceHandlerProtocol):
         alert_data = {}
         for signature in signatures:
             sig_value = signature.label.value
-            try:
-                value = getattr(oaev_data, sig_value)
-            except AttributeError:
-                pass
-            else:
-                alert_data[sig_value] = signature.make_struct_for_matching(value)
+            if sig_value in signature_groups:
+                try:
+                    value = getattr(oaev_data, sig_value)
+                except AttributeError:
+                    pass
+                else:
+                    alert_data[sig_value] = signature.make_struct_for_matching(value)
 
         if not alert_data:
             return False
 
-        available_expectation_signatures = set(sig["type"] for sig in signature_groups)
-        available_alert_signatures = set(sig for sig in alert_data)
-        available_signatures = available_expectation_signatures.intersection(
-            available_alert_signatures
-        )
-        signature_groups = [
-            element
-            for element in signature_groups
-            if element["type"] in available_signatures
-        ]
-        if not signature_groups:
-            return False
-
-        alert_data = {
-            key: value
-            for key, value in alert_data.items()
-            if key in available_signatures
-        }
-        if not alert_data:
-            return False
-
-        match_result = oaev_detection_helper.match_alert_elements(
-            signatures=signature_groups,
-            alert_data=alert_data,
-        )
-        return match_result
+        for sig_type, signature_data in signature_groups.items():
+            if sig_type not in alert_data:
+                # if an expected signature type is not available in the alert data,
+                # then no need to use the matcher
+                return False
+            match_result = oaev_detection_helper.match_alert_elements(
+                signatures=signature_data,
+                alert_data={sig_type: alert_data[sig_type]},
+            )
+            if not match_result:
+                # since matching must be done on all provided signatures,
+                # cf. behavior of the helper in pyoaev,
+                # fail-fast as soon as one misses
+                return False
+        return True
 
     @staticmethod
     def serialize_as_tracedata(data: SourceDataProtocol) -> TraceData:

--- a/template/src/collector/protocols/engine.py
+++ b/template/src/collector/protocols/engine.py
@@ -1,6 +1,6 @@
 from typing import Protocol, runtime_checkable
 
-from pyoaev.client import OpenAEV
+from pyoaev.client import OpenAEV  # type: ignore[import-untyped]
 from src.collector.models.source import Source
 from src.collector.protocols.source_handler import SourceHandlerProtocol
 from src.collector.types.collector import SourceConfig

--- a/template/src/collector/protocols/source_handler.py
+++ b/template/src/collector/protocols/source_handler.py
@@ -10,6 +10,7 @@ from src.collector.models.data import OAEVData, TraceData
 from src.collector.protocols.data_fetcher import DataFetcherProtocol
 from src.collector.protocols.source_data import SourceDataProtocol
 from src.collector.types.collector import (
+    AlertData,
     SignatureGroups,
     SourceConfig,
 )
@@ -31,10 +32,16 @@ class SourceHandlerProtocol(Protocol):
         expectation: DetectionExpectation | PreventionExpectation,
     ) -> SignatureGroups: ...
 
-    def match_signature_groups_and_oaevdata(
+    def get_alert_data_from_oaev_data(
+        self,
+        signatures: list[SignatureType],
+        oaev_data: OAEVData,
+    ) -> AlertData: ...
+
+    def match_signature_groups_and_alert_data(
         self,
         signature_groups: SignatureGroups,
-        oaev_data: OAEVData,
+        alert_data: AlertData,
         oaev_detection_helper: OpenAEVDetectionHelper,
     ) -> bool: ...
 

--- a/template/src/collector/protocols/source_handler.py
+++ b/template/src/collector/protocols/source_handler.py
@@ -1,15 +1,18 @@
 from typing import Protocol, runtime_checkable
 
-from pyoaev.apis.inject_expectation.model.expectation import (
+from pyoaev.apis.inject_expectation.model.expectation import (  # type: ignore[import-untyped]
     DetectionExpectation,
     PreventionExpectation,
 )
-from pyoaev.helpers import OpenAEVDetectionHelper
-from pyoaev.signatures.types import SignatureTypes
+from pyoaev.helpers import OpenAEVDetectionHelper  # type: ignore[import-untyped]
+from pyoaev.signatures.signature_type import SignatureType
 from src.collector.models.data import OAEVData, TraceData
 from src.collector.protocols.data_fetcher import DataFetcherProtocol
 from src.collector.protocols.source_data import SourceDataProtocol
-from src.collector.types.collector import SignatureGroups, SourceConfig
+from src.collector.types.collector import (
+    SignatureGroups,
+    SourceConfig,
+)
 
 
 @runtime_checkable
@@ -24,7 +27,7 @@ class SourceHandlerProtocol(Protocol):
 
     def get_expectation_signature_groups(
         self,
-        signatures: list[SignatureTypes],
+        signatures: list[SignatureType],
         expectation: DetectionExpectation | PreventionExpectation,
     ) -> SignatureGroups: ...
 

--- a/template/src/collector/types/collector.py
+++ b/template/src/collector/types/collector.py
@@ -1,6 +1,6 @@
 from typing import Sequence, TypeAlias
 
-from pyoaev.apis.inject_expectation.model import (
+from pyoaev.apis.inject_expectation.model import (  # type: ignore[import-untyped]
     DetectionExpectation,
     PreventionExpectation,
 )
@@ -8,4 +8,4 @@ from src.models.settings.source_configs import _ConfigLoaderSource
 
 SourceConfig: TypeAlias = _ConfigLoaderSource
 ExpectationsList: TypeAlias = Sequence[DetectionExpectation | PreventionExpectation]
-SignatureGroups: TypeAlias = dict[str, list[dict[str, str]]]
+SignatureGroups: TypeAlias = list[dict[str, str]]

--- a/template/src/collector/types/collector.py
+++ b/template/src/collector/types/collector.py
@@ -9,3 +9,4 @@ from src.models.settings.source_configs import _ConfigLoaderSource
 SourceConfig: TypeAlias = _ConfigLoaderSource
 ExpectationsList: TypeAlias = Sequence[DetectionExpectation | PreventionExpectation]
 SignatureGroups: TypeAlias = dict[str, list[dict[str, str]]]
+AlertData: TypeAlias = dict[str, dict[str, str]]

--- a/template/src/collector/types/collector.py
+++ b/template/src/collector/types/collector.py
@@ -8,4 +8,4 @@ from src.models.settings.source_configs import _ConfigLoaderSource
 
 SourceConfig: TypeAlias = _ConfigLoaderSource
 ExpectationsList: TypeAlias = Sequence[DetectionExpectation | PreventionExpectation]
-SignatureGroups: TypeAlias = list[dict[str, str]]
+SignatureGroups: TypeAlias = dict[str, list[dict[str, str]]]

--- a/template/src/source/template_signatures.py
+++ b/template/src/source/template_signatures.py
@@ -1,7 +1,15 @@
-from pyoaev.signatures.types import SignatureTypes
+from pyoaev.signatures.signature_type import SignatureType
+from pyoaev.signatures.types import (
+    MatchTypes,
+    SignatureTypes,
+)
 
-SUPPORTED_SIGNATURES = [
-    SignatureTypes.SIG_TYPE_END_DATE,
-    SignatureTypes.SIG_TYPE_START_DATE,
-    SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME,
+SUPPORTED_SIGNATURES: list[SignatureType] = [
+    SignatureType(SignatureTypes.SIG_TYPE_END_DATE),
+    SignatureType(SignatureTypes.SIG_TYPE_START_DATE),
+    SignatureType(
+        SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME,
+        match_type=MatchTypes.MATCH_TYPE_FUZZY,
+        match_score=60,
+    ),
 ]

--- a/template/tests/collector/engines/test_basic.py
+++ b/template/tests/collector/engines/test_basic.py
@@ -394,6 +394,7 @@ class TestBasicCollectorEngine(unittest.TestCase):
             source_handler.get_expectation_signature_groups.return_value,
             source_handler.serialize_as_oaevdata.return_value,
             collector_engine.oaev_detection_helper,
+            source.signatures,
         )
         source_handler.serialize_as_tracedata.assert_called_with(data_element)
 

--- a/template/tests/collector/engines/test_basic.py
+++ b/template/tests/collector/engines/test_basic.py
@@ -390,11 +390,15 @@ class TestBasicCollectorEngine(unittest.TestCase):
             source.signatures, expectation3
         )
 
-        source_handler.match_signature_groups_and_oaevdata.assert_any_call(
-            source_handler.get_expectation_signature_groups.return_value,
-            source_handler.serialize_as_oaevdata.return_value,
-            collector_engine.oaev_detection_helper,
+        source_handler.get_alert_data_from_oaev_data.assert_called_with(
             source.signatures,
+            source_handler.serialize_as_oaevdata.return_value,
+        )
+
+        source_handler.match_signature_groups_and_alert_data.assert_any_call(
+            source_handler.get_expectation_signature_groups.return_value,
+            source_handler.get_alert_data_from_oaev_data.return_value,
+            collector_engine.oaev_detection_helper,
         )
         source_handler.serialize_as_tracedata.assert_called_with(data_element)
 

--- a/template/tests/collector/models/test_source.py
+++ b/template/tests/collector/models/test_source.py
@@ -187,80 +187,111 @@ class SourceHandlerTest(unittest.TestCase):
             )
         )
 
-    def test_match_signature_groups_and_oaevdata_success(self):
+    def test_get_alert_data_from_oaev_data_success(self):
+        sig_value = "sig_value"
+        signature = MagicMock()
+        signature.label.value = sig_value
+        signatures = [signature]
+        oaev_data = MagicMock()
+        value = MagicMock()
+        oaev_data.sig_value = value
+        config = MagicMock()
+
+        source_handler = module.SourceHandler(config=config)
+
+        alert_data = source_handler.get_alert_data_from_oaev_data(
+            signatures, oaev_data,
+        )
+
+        signature.make_struct_for_matching.assert_called_once_with(value)
+        self.assertEqual(
+            alert_data,
+            {sig_value: signature.make_struct_for_matching.return_value}
+        )
+
+    def test_get_alert_data_from_oaev_data_empty(self):
+        sig_value = "sig_value"
+        signature = MagicMock()
+        signature.label.value = sig_value
+        signatures = [signature]
+        oaev_data = None
+        config = MagicMock()
+
+        source_handler = module.SourceHandler(config=config)
+
+        alert_data = source_handler.get_alert_data_from_oaev_data(
+            signatures, oaev_data,
+        )
+
+        signature.make_struct_for_matching.assert_not_called()
+        self.assertEqual(
+            alert_data,
+            {},
+        )
+
+    def test_match_signature_groups_and_alert_data_success(self):
         """
         testing the calls made to oaev detection helper by the source handler
         for a successful matching
         """
         _type = "my_type"
         signature_groups = {_type: {"type": _type, "value": "my_value"}}
-        oaev_data = MagicMock()
+        alert_data = {_type: MagicMock()}
         oaev_detection_helper = MagicMock()
         oaev_detection_helper.match_alert_elements.return_value = True
-        signature = MagicMock()
-        signature.label.value = _type
-        signatures = [signature]
         config = MagicMock()
 
         source_handler = module.SourceHandler(config=config)
 
-        flag = source_handler.match_signature_groups_and_oaevdata(
-            signature_groups, oaev_data, oaev_detection_helper, signatures
+        flag = source_handler.match_signature_groups_and_alert_data(
+            signature_groups, alert_data, oaev_detection_helper,
         )
 
         oaev_detection_helper.match_alert_elements.assert_called_with(
             signatures=signature_groups[_type],
-            alert_data={_type: signature.make_struct_for_matching.return_value},
+            alert_data={_type: alert_data[_type]}
         )
-        signature.make_struct_for_matching.assert_called_with(oaev_data.my_type)
         self.assertTrue(flag)
 
-    def test_match_signature_groups_and_oaevdata_failure(self):
+    def test_match_signature_groups_and_alert_data_failure(self):
         """
         testing the calls made to oaev detection helper by the source handler
         for a failed matching
         """
         _type = "my_type"
         signature_groups = {_type: {"type": _type, "value": "my_value"}}
-        oaev_data = MagicMock()
+        alert_data = {_type: MagicMock()}
         oaev_detection_helper = MagicMock()
         oaev_detection_helper.match_alert_elements.return_value = False
-        signature = MagicMock()
-        signature.label.value = _type
-        signatures = [signature]
         config = MagicMock()
 
         source_handler = module.SourceHandler(config=config)
 
-        flag = source_handler.match_signature_groups_and_oaevdata(
-            signature_groups, oaev_data, oaev_detection_helper, signatures
+        flag = source_handler.match_signature_groups_and_alert_data(
+            signature_groups, alert_data, oaev_detection_helper,
         )
 
         oaev_detection_helper.match_alert_elements.assert_called_with(
             signatures=signature_groups[_type],
-            alert_data={_type: signature.make_struct_for_matching.return_value},
+            alert_data={_type: alert_data[_type]}
         )
-        signature.make_struct_for_matching.assert_called_with(oaev_data.my_type)
         self.assertFalse(flag)
 
-    def test_match_signature_groups_and_oaevdata_empty(self):
+    def test_match_signature_groups_and_alert_data_empty(self):
         """
         testing the calls made to oaev detection helper by the source handler
         for an empty input
         """
         signature_groups = [{"type": "my_type", "value": "my_value"}]
-        oaev_data = None
+        alert_data = None
         oaev_detection_helper = MagicMock()
         oaev_detection_helper.match_alert_elements.return_value = True
-        signature = MagicMock()
-        signature.label.value = "my_type"
-        signatures = [signature]
         config = MagicMock()
 
         source_handler = module.SourceHandler(config=config)
 
-        flag = source_handler.match_signature_groups_and_oaevdata(
-            signature_groups, oaev_data, oaev_detection_helper, signatures
+        flag = source_handler.match_signature_groups_and_alert_data(
+            signature_groups, alert_data, oaev_detection_helper,
         )
 
         oaev_detection_helper.match_alert_elements.assert_not_called()

--- a/template/tests/collector/models/test_source.py
+++ b/template/tests/collector/models/test_source.py
@@ -34,9 +34,7 @@ class SourceTest(unittest.TestCase):
         self.data_fetcher_model = FakeDataFetcher
 
         self.signatures = [
-            module.SignatureType(
-                module.SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME
-            )
+            module.SignatureType(module.SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME)
         ]
 
     def test_source_good_init(self):
@@ -179,12 +177,14 @@ class SourceHandlerTest(unittest.TestCase):
         )
 
         self.assertEqual(1, len(signature_groups))
-        self.assertIn(
-            {"type": "my_type", "value": "my_value"}, signature_groups
+        self.assertEqual(
+            [{"type": "my_type", "value": "my_value"}], signature_groups["my_type"]
         )
-        self.assertNotIn(
-            {"type": "my_type", "value": "my_other_value"},
-            signature_groups,
+        self.assertFalse(
+            any(
+                value == [{"type": "my_type", "value": "my_other_value"}]
+                for value in signature_groups.values()
+            )
         )
 
     def test_match_signature_groups_and_oaevdata_success(self):
@@ -192,12 +192,13 @@ class SourceHandlerTest(unittest.TestCase):
         testing the calls made to oaev detection helper by the source handler
         for a successful matching
         """
-        signature_groups = [{"type": "my_type", "value": "my_value"}]
+        _type = "my_type"
+        signature_groups = {_type: {"type": _type, "value": "my_value"}}
         oaev_data = MagicMock()
         oaev_detection_helper = MagicMock()
         oaev_detection_helper.match_alert_elements.return_value = True
         signature = MagicMock()
-        signature.label.value = "my_type"
+        signature.label.value = _type
         signatures = [signature]
         config = MagicMock()
 
@@ -208,8 +209,8 @@ class SourceHandlerTest(unittest.TestCase):
         )
 
         oaev_detection_helper.match_alert_elements.assert_called_with(
-            signatures=signature_groups,
-            alert_data={"my_type": signature.make_struct_for_matching.return_value}
+            signatures=signature_groups[_type],
+            alert_data={_type: signature.make_struct_for_matching.return_value},
         )
         signature.make_struct_for_matching.assert_called_with(oaev_data.my_type)
         self.assertTrue(flag)
@@ -219,12 +220,13 @@ class SourceHandlerTest(unittest.TestCase):
         testing the calls made to oaev detection helper by the source handler
         for a failed matching
         """
-        signature_groups = [{"type": "my_type", "value": "my_value"}]
+        _type = "my_type"
+        signature_groups = {_type: {"type": _type, "value": "my_value"}}
         oaev_data = MagicMock()
         oaev_detection_helper = MagicMock()
         oaev_detection_helper.match_alert_elements.return_value = False
         signature = MagicMock()
-        signature.label.value = "my_type"
+        signature.label.value = _type
         signatures = [signature]
         config = MagicMock()
 
@@ -235,8 +237,8 @@ class SourceHandlerTest(unittest.TestCase):
         )
 
         oaev_detection_helper.match_alert_elements.assert_called_with(
-            signatures=signature_groups,
-            alert_data={"my_type": signature.make_struct_for_matching.return_value}
+            signatures=signature_groups[_type],
+            alert_data={_type: signature.make_struct_for_matching.return_value},
         )
         signature.make_struct_for_matching.assert_called_with(oaev_data.my_type)
         self.assertFalse(flag)

--- a/template/tests/collector/models/test_source.py
+++ b/template/tests/collector/models/test_source.py
@@ -158,7 +158,7 @@ class SourceHandlerTest(unittest.TestCase):
         signature.label = _type
         signatures = [signature]
         inject_expectation_signature_1 = MagicMock(type=_type, value="my_value")
-        inject_expectation_signature_2 = MagicMock(value="my_other_value")
+        inject_expectation_signature_2 = MagicMock(type=_type, value="my_other_value")
         end_date_type = MagicMock(value="end_date")
         end_date_ies = MagicMock(type=end_date_type, value="now")
         expectation = MagicMock(
@@ -177,12 +177,17 @@ class SourceHandlerTest(unittest.TestCase):
         )
 
         self.assertEqual(1, len(signature_groups))
+        self.assertEqual(2, len(signature_groups[_type.value]))
         self.assertEqual(
-            [{"type": "my_type", "value": "my_value"}], signature_groups["my_type"]
+            [
+                {"type": "my_type", "value": "my_value"},
+                {"type": "my_type", "value": "my_other_value"},
+            ],
+            signature_groups["my_type"],
         )
         self.assertFalse(
             any(
-                value == [{"type": "my_type", "value": "my_other_value"}]
+                value == [{"type": "end_date", "value": "now"}]
                 for value in signature_groups.values()
             )
         )
@@ -236,7 +241,7 @@ class SourceHandlerTest(unittest.TestCase):
         for a successful matching
         """
         _type = "my_type"
-        signature_groups = {_type: {"type": _type, "value": "my_value"}}
+        signature_groups = {_type: [{"type": _type, "value": "my_value"}]}
         alert_data = {_type: MagicMock()}
         oaev_detection_helper = MagicMock()
         oaev_detection_helper.match_alert_elements.return_value = True
@@ -261,7 +266,7 @@ class SourceHandlerTest(unittest.TestCase):
         for a failed matching
         """
         _type = "my_type"
-        signature_groups = {_type: {"type": _type, "value": "my_value"}}
+        signature_groups = {_type: [{"type": _type, "value": "my_value"}]}
         alert_data = {_type: MagicMock()}
         oaev_detection_helper = MagicMock()
         oaev_detection_helper.match_alert_elements.return_value = False
@@ -285,7 +290,8 @@ class SourceHandlerTest(unittest.TestCase):
         testing the calls made to oaev detection helper by the source handler
         for an empty input
         """
-        signature_groups = [{"type": "my_type", "value": "my_value"}]
+        _type = "my_type"
+        signature_groups = {_type: [{"type": "my_type", "value": "my_value"}]}
         alert_data = None
         oaev_detection_helper = MagicMock()
         oaev_detection_helper.match_alert_elements.return_value = True

--- a/template/tests/collector/models/test_source.py
+++ b/template/tests/collector/models/test_source.py
@@ -200,13 +200,13 @@ class SourceHandlerTest(unittest.TestCase):
         source_handler = module.SourceHandler(config=config)
 
         alert_data = source_handler.get_alert_data_from_oaev_data(
-            signatures, oaev_data,
+            signatures,
+            oaev_data,
         )
 
         signature.make_struct_for_matching.assert_called_once_with(value)
         self.assertEqual(
-            alert_data,
-            {sig_value: signature.make_struct_for_matching.return_value}
+            alert_data, {sig_value: signature.make_struct_for_matching.return_value}
         )
 
     def test_get_alert_data_from_oaev_data_empty(self):
@@ -220,7 +220,8 @@ class SourceHandlerTest(unittest.TestCase):
         source_handler = module.SourceHandler(config=config)
 
         alert_data = source_handler.get_alert_data_from_oaev_data(
-            signatures, oaev_data,
+            signatures,
+            oaev_data,
         )
 
         signature.make_struct_for_matching.assert_not_called()
@@ -244,12 +245,13 @@ class SourceHandlerTest(unittest.TestCase):
         source_handler = module.SourceHandler(config=config)
 
         flag = source_handler.match_signature_groups_and_alert_data(
-            signature_groups, alert_data, oaev_detection_helper,
+            signature_groups,
+            alert_data,
+            oaev_detection_helper,
         )
 
         oaev_detection_helper.match_alert_elements.assert_called_with(
-            signatures=signature_groups[_type],
-            alert_data={_type: alert_data[_type]}
+            signatures=signature_groups[_type], alert_data={_type: alert_data[_type]}
         )
         self.assertTrue(flag)
 
@@ -268,12 +270,13 @@ class SourceHandlerTest(unittest.TestCase):
         source_handler = module.SourceHandler(config=config)
 
         flag = source_handler.match_signature_groups_and_alert_data(
-            signature_groups, alert_data, oaev_detection_helper,
+            signature_groups,
+            alert_data,
+            oaev_detection_helper,
         )
 
         oaev_detection_helper.match_alert_elements.assert_called_with(
-            signatures=signature_groups[_type],
-            alert_data={_type: alert_data[_type]}
+            signatures=signature_groups[_type], alert_data={_type: alert_data[_type]}
         )
         self.assertFalse(flag)
 
@@ -291,7 +294,9 @@ class SourceHandlerTest(unittest.TestCase):
         source_handler = module.SourceHandler(config=config)
 
         flag = source_handler.match_signature_groups_and_alert_data(
-            signature_groups, alert_data, oaev_detection_helper,
+            signature_groups,
+            alert_data,
+            oaev_detection_helper,
         )
 
         oaev_detection_helper.match_alert_elements.assert_not_called()

--- a/template/tests/collector/models/test_source.py
+++ b/template/tests/collector/models/test_source.py
@@ -33,7 +33,11 @@ class SourceTest(unittest.TestCase):
 
         self.data_fetcher_model = FakeDataFetcher
 
-        self.signatures = [module.SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME]
+        self.signatures = [
+            module.SignatureType(
+                module.SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME
+            )
+        ]
 
     def test_source_good_init(self):
         """
@@ -151,11 +155,12 @@ class SourceHandlerTest(unittest.TestCase):
         through the get_expectation_signature_groups function
         """
         value = "my_type"
-        signature = MagicMock(value=value)
-        signatures = [signature]
         _type = MagicMock(value=value)
+        signature = MagicMock()
+        signature.label = _type
+        signatures = [signature]
         inject_expectation_signature_1 = MagicMock(type=_type, value="my_value")
-        inject_expectation_signature_2 = MagicMock(type=_type, value="my_other_value")
+        inject_expectation_signature_2 = MagicMock(value="my_other_value")
         end_date_type = MagicMock(value="end_date")
         end_date_ies = MagicMock(type=end_date_type, value="now")
         expectation = MagicMock(
@@ -174,13 +179,12 @@ class SourceHandlerTest(unittest.TestCase):
         )
 
         self.assertEqual(1, len(signature_groups))
-        self.assertEqual(2, len(signature_groups.get("my_type")))
         self.assertIn(
-            {"type": "my_type", "value": "my_value"}, signature_groups.get("my_type")
+            {"type": "my_type", "value": "my_value"}, signature_groups
         )
-        self.assertIn(
+        self.assertNotIn(
             {"type": "my_type", "value": "my_other_value"},
-            signature_groups.get("my_type"),
+            signature_groups,
         )
 
     def test_match_signature_groups_and_oaevdata_success(self):
@@ -188,21 +192,26 @@ class SourceHandlerTest(unittest.TestCase):
         testing the calls made to oaev detection helper by the source handler
         for a successful matching
         """
-        signature_groups = {"my_type": [{"type": "my_type", "value": "my_value"}]}
+        signature_groups = [{"type": "my_type", "value": "my_value"}]
         oaev_data = MagicMock()
         oaev_detection_helper = MagicMock()
         oaev_detection_helper.match_alert_elements.return_value = True
+        signature = MagicMock()
+        signature.label.value = "my_type"
+        signatures = [signature]
         config = MagicMock()
 
         source_handler = module.SourceHandler(config=config)
 
         flag = source_handler.match_signature_groups_and_oaevdata(
-            signature_groups, oaev_data, oaev_detection_helper
+            signature_groups, oaev_data, oaev_detection_helper, signatures
         )
 
         oaev_detection_helper.match_alert_elements.assert_called_with(
-            signature_groups["my_type"], {"my_type": oaev_data.my_type}
+            signatures=signature_groups,
+            alert_data={"my_type": signature.make_struct_for_matching.return_value}
         )
+        signature.make_struct_for_matching.assert_called_with(oaev_data.my_type)
         self.assertTrue(flag)
 
     def test_match_signature_groups_and_oaevdata_failure(self):
@@ -210,21 +219,26 @@ class SourceHandlerTest(unittest.TestCase):
         testing the calls made to oaev detection helper by the source handler
         for a failed matching
         """
-        signature_groups = {"my_type": [{"type": "my_type", "value": "my_value"}]}
+        signature_groups = [{"type": "my_type", "value": "my_value"}]
         oaev_data = MagicMock()
         oaev_detection_helper = MagicMock()
         oaev_detection_helper.match_alert_elements.return_value = False
+        signature = MagicMock()
+        signature.label.value = "my_type"
+        signatures = [signature]
         config = MagicMock()
 
         source_handler = module.SourceHandler(config=config)
 
         flag = source_handler.match_signature_groups_and_oaevdata(
-            signature_groups, oaev_data, oaev_detection_helper
+            signature_groups, oaev_data, oaev_detection_helper, signatures
         )
 
         oaev_detection_helper.match_alert_elements.assert_called_with(
-            signature_groups["my_type"], {"my_type": oaev_data.my_type}
+            signatures=signature_groups,
+            alert_data={"my_type": signature.make_struct_for_matching.return_value}
         )
+        signature.make_struct_for_matching.assert_called_with(oaev_data.my_type)
         self.assertFalse(flag)
 
     def test_match_signature_groups_and_oaevdata_empty(self):
@@ -232,16 +246,19 @@ class SourceHandlerTest(unittest.TestCase):
         testing the calls made to oaev detection helper by the source handler
         for an empty input
         """
-        signature_groups = {"my_type": [{"type": "my_type", "value": "my_value"}]}
+        signature_groups = [{"type": "my_type", "value": "my_value"}]
         oaev_data = None
         oaev_detection_helper = MagicMock()
         oaev_detection_helper.match_alert_elements.return_value = True
+        signature = MagicMock()
+        signature.label.value = "my_type"
+        signatures = [signature]
         config = MagicMock()
 
         source_handler = module.SourceHandler(config=config)
 
         flag = source_handler.match_signature_groups_and_oaevdata(
-            signature_groups, oaev_data, oaev_detection_helper
+            signature_groups, oaev_data, oaev_detection_helper, signatures
         )
 
         oaev_detection_helper.match_alert_elements.assert_not_called()

--- a/template/tests/collector/protocols/test_source_handler.py
+++ b/template/tests/collector/protocols/test_source_handler.py
@@ -18,8 +18,11 @@ class SourceHandlerProtocolTest(unittest.TestCase):
             def get_expectation_signature_groups(self, signatures, expectations):
                 return [{"foo": "bar"}]
 
-            def match_signature_groups_and_oaevdata(
-                self, signature_groups, oaev_data, oaev_detection_helper
+            def get_alert_data_from_oaev_data(self, signatures, oaev_data):
+                return {"foo": {}}
+
+            def match_signature_groups_and_alert_data(
+                self, signature_groups, alert_data, oaev_detection_helper
             ):
                 return True
 
@@ -41,8 +44,11 @@ class SourceHandlerProtocolTest(unittest.TestCase):
             def get_expectation_signature_groups(self, signatures, expectations):
                 return [{"foo": "bar"}]
 
-            def match_signature_groups_and_oaevdata(
-                self, signature_groups, oaev_data, oaev_detection_helper
+            def get_alert_data_from_oaev_data(self, signatures, oaev_data):
+                return {"foo": {}}
+
+            def match_signature_groups_and_alert_data(
+                self, signature_groups, alert_data, oaev_detection_helper
             ):
                 return True
 
@@ -68,8 +74,11 @@ class SourceHandlerProtocolTest(unittest.TestCase):
             def get_expectation_signature_groups(self, signatures, expectations):
                 return [{"foo": "bar"}]
 
-            def match_signature_groups_and_oaevdata(
-                self, signature_groups, oaev_data, oaev_detection_helper
+            def get_alert_data_from_oaev_data(self, signatures, oaev_data):
+                return {"foo": {}}
+
+            def match_signature_groups_and_alert_data(
+                self, signature_groups, alert_data, oaev_detection_helper
             ):
                 return True
 
@@ -97,8 +106,11 @@ class SourceHandlerProtocolTest(unittest.TestCase):
             def serialize_as_oaevdata(self, data):
                 return MagicMock()
 
-            def match_signature_groups_and_oaevdata(
-                self, signature_groups, oaev_data, oaev_detection_helper
+            def get_alert_data_from_oaev_data(self, signatures, oaev_data):
+                return {"foo": {}}
+
+            def match_signature_groups_and_alert_data(
+                self, signature_groups, alert_data, oaev_detection_helper
             ):
                 return True
 
@@ -185,8 +197,11 @@ class SourceHandlerProtocolTest(unittest.TestCase):
             def get_expectation_signature_groups(self, signatures, expectations):
                 return [{"foo": "bar"}]
 
-            def match_signature_groups_and_oaevdata(
-                self, signature_groups, oaev_data, oaev_detection_helper
+            def get_alert_data_from_oaev_data(self, signatures, oaev_data):
+                return {"foo": {}}
+
+            def match_signature_groups_and_alert_data(
+                self, signature_groups, alert_data, oaev_detection_helper
             ):
                 return True
 


### PR DESCRIPTION
### Proposed changes

* fixing a failure of the helper-based matching system due to a confusion between `SignatureTypes` (an `Enum` in `pyoaev.signatures.types`) and `SignatureType` (a wrapper in `pyoaev.signatures.signature_type`)
  * `SUPPORTED_SIGNATURES` in `/src/source/signatures.py` moving from a list of `SignatureTypes` to a list of `SignatureType`, and thus providing the metadata required for proper matching if relevant (fuzzy or not, score level)
  * using `SignatureType.make_struct_for_matching` inside the source handler to produce said matching metadata
  * creating a type alias `AlertData` for the format expected to be fed into the helper for better typechecking/understanding of the codebase
* splitting step (4) of the engine, `match_signature_groups_and_oaevdata` into two new steps for better engineering:
  * `get_alert_data_from_oaev_data` turning the `OAEVData` into the data expected by the oaev helper (using said `make_struct_for_matching`)
  * `match_signature_groups_and_alert_data`, feeding both elements (signature groups and alert data) into the helper
* improving typing / typechecking-experience based on the modifications made to the copy-pasted template during the development of o365

And
* propagating all those fixes, updates and changes made to the template to `microsoft-defender-o365`
  * by default, all the current signatures were turned into basic `SignatureType()` with no specification, the default match type will thus be used (`simple`)

Note: all the issues discovered while reusing the `template` and the data fetcher of `microsoft-defender-o365` for `microsoft-defender` in PR #555 have been ported into this PR too.

### Testing Instructions

1. Partially rely on the testing results of #555 due to having both the template'd `collector` codebase and the alerts v2 data fetcher codebase in common
2. End-to-end testing

### Related issues

* Closes #568 
* Relates #582 (maybe closes, unclear for now)

### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [ ] I consider the submitted work as finished
- [ ] I tested the code for its functionality
- [ ] I wrote test cases for the relevant uses case
- [ ] I added/update the relevant documentation (either on github or on notion)
- [ ] Where necessary I refactored code to improve the overall quality
- [ ] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...-->
