### PR TITLE
feat(splunk_es): enhanced process name retrieval from _raw fields (#489)

### DIFF
--- a/splunk-es/src/services/converter.py
+++ b/splunk-es/src/services/converter.py
@@ -159,15 +159,15 @@ class Converter:
                 }
                 self.logger.debug(f"{LOG_PREFIX} Using target IPs: {target_ips}")
 
-            parent_process_name = self._extract_parent_process_name(alert_data)
-            if parent_process_name:
+            parent_process_names = self._extract_parent_process_name(alert_data)
+            if parent_process_names:
                 oaev_data["parent_process_name"] = {
                     "type": "fuzzy",
-                    "data": [parent_process_name],
+                    "data": parent_process_names,
                     "score": 95,
                 }
                 self.logger.debug(
-                    f"{LOG_PREFIX} Using parent process name: {parent_process_name}"
+                    f"{LOG_PREFIX} Using parent process name(s): {parent_process_names}"
                 )
 
             if alert_data.signature:
@@ -226,47 +226,33 @@ class Converter:
 
         return target_ips
 
-    def _extract_parent_process_name(self, alert_data: SplunkESAlert) -> str:
-        """Extract parent process name from alert data.
+    def _extract_parent_process_name(self, alert_data: SplunkESAlert) -> list[str]:
+        """Extract parent process name(s) from alert data.
 
-        This method reconstructs the parent process name from the URL path
-        found in the alert data.
+        First attempts to extract from url_path by reconstructing from UUIDs.
+        If that fails, falls back to scanning _raw for the parent process name
+        pattern and returns matches directly.
 
         Args:
             alert_data: SplunkESAlert object.
 
         Returns:
-            Reconstructed parent process name if UUIDs found in URL path, empty string otherwise.
+            List of parent process names, empty list if none found.
 
         """
-        if not alert_data.url_path:
-            self.logger.debug(f"{LOG_PREFIX} No URL path found in alert data")
-            return ""
-
-        try:
-            self.logger.debug(
-                f"{LOG_PREFIX} Extracting parent process name from URL path: {alert_data.url_path}"
-            )
-
+        if alert_data.url_path:
             uuids = self.parent_process_parser.extract_uuids_from_url_path(
                 alert_data.url_path
             )
             if uuids:
-                inject_uuid, agent_uuid = uuids
                 parent_process_name = (
                     self.parent_process_parser.construct_parent_process_name(
-                        inject_uuid, agent_uuid
+                        uuids[0], uuids[1]
                     )
                 )
-                self.logger.debug(
-                    f"{LOG_PREFIX} Reconstructed parent process name: {parent_process_name}"
-                )
-                return parent_process_name
-            else:
-                self.logger.debug(
-                    f"{LOG_PREFIX} No UUIDs found in URL path: {alert_data.url_path}"
-                )
-                return ""
-        except Exception as e:
-            self.logger.error(f"{LOG_PREFIX} Error extracting parent process name: {e}")
-            return ""
+                if parent_process_name:
+                    return [parent_process_name]
+
+        return self.parent_process_parser.extract_parent_process_names_from_raw(
+            alert_data._raw
+        )

--- a/splunk-es/src/services/utils/parent_process_parser.py
+++ b/splunk-es/src/services/utils/parent_process_parser.py
@@ -6,7 +6,7 @@ and reconstruct them for matching purposes.
 
 import logging
 import re
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 LOG_PREFIX = "[ParentProcessParser]"
 
@@ -22,6 +22,9 @@ class ParentProcessParser:
             r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
         )
         self.parent_process_pattern = r"oaev-implant-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-agent-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
+        self._compiled_parent_process_re = re.compile(
+            self.parent_process_pattern, re.IGNORECASE
+        )
 
     def extract_uuids_from_parent_process_name(
         self, parent_process_name: str
@@ -187,6 +190,36 @@ class ParentProcessParser:
         except Exception as e:
             self.logger.error(f"{LOG_PREFIX} Error building URL path search query: {e}")
             return ""
+
+    def extract_parent_process_names_from_raw(
+        self, raw_data: dict[str, Any]
+    ) -> list[str]:
+        """Extract all parent process names from flattened _raw alert data.
+
+        Flattens the _raw dictionary to a single string and searches for
+        all occurrences of the parent process name pattern.
+
+        Args:
+            raw_data: The _raw dictionary from a SplunkESAlert.
+
+        Returns:
+            List of parent process names found, empty list if none.
+
+        """
+        if not raw_data:
+            return []
+
+        try:
+            raw_string = " ".join(str(v) for v in raw_data.values() if v is not None)
+            return [
+                match.group(0)
+                for match in self._compiled_parent_process_re.finditer(raw_string)
+            ]
+        except Exception as e:
+            self.logger.error(
+                f"{LOG_PREFIX} Error extracting parent process names from _raw: {e}"
+            )
+            return []
 
     def validate_uuid_format(self, uuid_string: str) -> bool:
         """Validate if string matches UUID format.

--- a/splunk-es/tests/services/test_converter_parent_process_raw_fallback.py
+++ b/splunk-es/tests/services/test_converter_parent_process_raw_fallback.py
@@ -1,0 +1,180 @@
+"""Tests for parent process name extraction fallback from _raw alert data.
+
+This module tests the enhancement where the converter falls back to scanning
+the _raw alert data for the parent process name pattern when url_path
+extraction fails.
+
+See: feat/489-splunkes-enhanced-process-name-retrieval
+"""
+
+from src.services.converter import Converter
+from src.services.models import SplunkESAlert
+
+
+class TestConverterParentProcessRawFallback:
+    """Test cases for parent process name extraction from _raw alert data.
+
+    Tests the fallback behaviour when url_path does not contain parseable
+    UUIDs but the _raw dict does contain the parent process name in the
+    format: oae-implant-{inject_uuid}-agent-{agent_uuid}
+    """
+
+    def test_extract_parent_process_name_from_url_path(self):
+        """Test extracting parent process name from a valid url_path.
+
+        Verifies that when url_path contains the expected OpenAEV callback
+        URL format, the parent process name is correctly reconstructed.
+        """
+        converter = Converter()
+        inject_uuid = "877b423b-ae91-4fc5-86c3-fa8ea3c938ba"
+        agent_uuid = "1402422f-2eaa-4fbd-80b2-b30df1b83b19"
+        url_path = f"/api/injects/{inject_uuid}/{agent_uuid}/executable-payload"
+
+        alert = SplunkESAlert(time="2024-01-01T12:30:00Z", url_path=url_path)
+
+        result = converter._extract_parent_process_name(alert)
+
+        assert result == [  # noqa: S101
+            f"oaev-implant-{inject_uuid}-agent-{agent_uuid}"
+        ]
+
+    def test_extract_parent_process_name_from_url_path_not_found(self):
+        """Test that extraction returns empty string when url_path has no UUIDs.
+
+        Verifies that when url_path is present but does not contain the
+        expected URL pattern, an empty string is returned.
+        """
+        converter = Converter()
+        alert = SplunkESAlert(
+            time="2024-01-01T12:30:00Z",
+            url_path="C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+        )
+
+        result = converter._extract_parent_process_name(alert)
+
+        assert result == []  # noqa: S101
+
+    def test_extract_parent_process_name_from_raw_when_url_path_fails(self):
+        """Test fallback to _raw when url_path extraction fails.
+
+        Verifies that when url_path does not contain parseable UUIDs, the
+        converter falls back to scanning _raw for the parent process name
+        pattern and returns the full process name directly.
+        """
+        converter = Converter()
+        inject_uuid = "877b423b-ae91-4fc5-86c3-fa8ea3c938ba"
+        agent_uuid = "1402422f-2eaa-4fbd-80b2-b30df1b83b19"
+        expected_process_name = f"oaev-implant-{inject_uuid}-agent-{agent_uuid}"
+
+        alert = SplunkESAlert(
+            time="2024-01-01T12:30:00Z",
+            url_path="C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+        )
+        alert._raw = {
+            "parent_process_name": expected_process_name,
+            "src": "192.168.1.100",
+            "dest": "10.0.0.50",
+        }
+
+        result = converter._extract_parent_process_name(alert)
+
+        assert result == [expected_process_name]  # noqa: S101
+
+    def test_extract_parent_process_name_from_raw_with_multiple_patterns(self):
+        """Test fallback to _raw when multiple process name patterns exist.
+
+        Verifies that when _raw contains multiple parent process name
+        patterns, all of them are extracted and returned.
+        """
+        converter = Converter()
+        inject_uuid_1 = "877b423b-ae91-4fc5-86c3-fa8ea3c938ba"
+        agent_uuid_1 = "1402422f-2eaa-4fbd-80b2-b30df1b83b19"
+        inject_uuid_2 = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        agent_uuid_2 = "f1e2d3c4-b5a6-9780-fedc-ba0987654321"
+        process_name_1 = f"oaev-implant-{inject_uuid_1}-agent-{agent_uuid_1}"
+        process_name_2 = f"oaev-implant-{inject_uuid_2}-agent-{agent_uuid_2}"
+
+        alert = SplunkESAlert(
+            time="2024-01-01T12:30:00Z",
+            url_path="C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+        )
+        alert._raw = {
+            "parent_process_name": process_name_1,
+            "process_name": process_name_2,
+            "src": "192.168.1.100",
+        }
+
+        result = converter._extract_parent_process_name(alert)
+
+        assert process_name_1 in result  # noqa: S101
+        assert process_name_2 in result  # noqa: S101
+
+    def test_extract_parent_process_name_url_path_takes_precedence(self):
+        """Test that url_path extraction takes precedence over _raw fallback.
+
+        Verifies that when both url_path and _raw contain valid data,
+        the url_path result is used (existing behaviour preserved).
+        """
+        converter = Converter()
+        inject_uuid_url = "11111111-2222-3333-4444-555555555555"
+        agent_uuid_url = "66666666-7777-8888-9999-aaaaaaaaaaaa"
+        inject_uuid_raw = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
+        agent_uuid_raw = "11111111-2222-3333-4444-555555555555"
+        url_path = f"/api/injects/{inject_uuid_url}/{agent_uuid_url}/executable-payload"
+        expected_from_url = f"oaev-implant-{inject_uuid_url}-agent-{agent_uuid_url}"
+        expected_from_raw = f"oaev-implant-{inject_uuid_raw}-agent-{agent_uuid_raw}"
+
+        alert = SplunkESAlert(time="2024-01-01T12:30:00Z", url_path=url_path)
+        alert._raw = {
+            "parent_process_name": expected_from_raw,
+        }
+
+        result = converter._extract_parent_process_name(alert)
+
+        assert result == [expected_from_url]  # noqa: S101
+        assert expected_from_raw not in result  # noqa: S101
+
+    def test_extract_parent_process_name_no_url_no_raw(self):
+        """Test extraction when neither url_path nor _raw contain data.
+
+        Verifies that when both url_path is empty and _raw has no parent
+        process name pattern, an empty string is returned.
+        """
+        converter = Converter()
+        alert = SplunkESAlert(time="2024-01-01T12:30:00Z")
+        alert._raw = {"src": "192.168.1.100", "dest": "10.0.0.50"}
+
+        result = converter._extract_parent_process_name(alert)
+
+        assert result == []  # noqa: S101
+
+    def test_convert_alert_with_raw_fallback_includes_parent_process(self):
+        """Test full conversion includes parent_process_name from _raw fallback.
+
+        Verifies that converting an alert with no parseable url_path but
+        a valid parent process name in _raw results in OAEV data containing
+        the parent_process_name field.
+        """
+        converter = Converter()
+        inject_uuid = "877b423b-ae91-4fc5-86c3-fa8ea3c938ba"
+        agent_uuid = "1402422f-2eaa-4fbd-80b2-b30df1b83b19"
+        expected_process_name = f"oaev-implant-{inject_uuid}-agent-{agent_uuid}"
+
+        alert = SplunkESAlert(
+            time="2024-01-01T12:30:00Z",
+            src_ip="192.168.1.100",
+            dst_ip="10.0.0.50",
+            url_path="C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+        )
+        alert._raw = {
+            "parent_process_name": expected_process_name,
+        }
+
+        result = converter.convert_data_to_oaev_data(alert)
+
+        assert len(result) == 1  # noqa: S101
+        assert "parent_process_name" in result[0]  # noqa: S101
+        assert result[0]["parent_process_name"]["type"] == "fuzzy"  # noqa: S101
+        assert (
+            expected_process_name in result[0]["parent_process_name"]["data"]
+        )  # noqa: S101

--- a/splunk-es/tests/services/test_converter_parent_process_raw_fallback.py
+++ b/splunk-es/tests/services/test_converter_parent_process_raw_fallback.py
@@ -16,7 +16,7 @@ class TestConverterParentProcessRawFallback:
 
     Tests the fallback behaviour when url_path does not contain parseable
     UUIDs but the _raw dict does contain the parent process name in the
-    format: oae-implant-{inject_uuid}-agent-{agent_uuid}
+    format: oaev-implant-{inject_uuid}-agent-{agent_uuid}
     """
 
     def test_extract_parent_process_name_from_url_path(self):


### PR DESCRIPTION
## Summary

Add a fallback mechanism to extract parent process names from raw alert data (`_raw`) when `url_path` parsing fails, increasing the collector's resilience to non-standard alert payloads.

## Related issue
As seen in the issue #489 

## Root Cause

The Splunk ES collector only extracted parent process names via a single path: parsing UUIDs from the `url_path` field and reconstructing the `oaev-implant-{inject_uuid}-agent-{agent_uuid}` format.

When alerts arrived with a `url_path` that didn't match the expected callback URL pattern (e.g., local paths like `C:\Windows\System32\powershell.exe`), the extraction silently returned empty — even though the parent process name was present elsewhere in the raw alert data.

**Why this is an enhancement, not a bug:** The existing `url_path` logic was correct for its intended path. The issue was the absence of a fallback mechanism for edge-case payloads, not a broken implementation.

## What Changed

### `ParentProcessParser` (`parent_process_parser.py`)
- Added `extract_parent_process_names_from_raw()` — flattens the `_raw` dict to a string and uses `re.finditer()` with the existing `oaev-implant-{UUID}-agent-{UUID}` pattern to extract full process name matches directly.
- Pre-compiled the regex (`_compiled_parent_process_re`) at init to avoid per-call compilation overhead.

### `Converter` (`converter.py`)
- `_extract_parent_process_name()` now returns `list[str]` and implements a two-step extraction:
  1. **Primary:** Attempt UUID extraction from `url_path` (existing behavior, unchanged).
  2. **Fallback:** If `url_path` yields no result, scan `_raw` for parent process name patterns.
- `_alert_data()` updated to consume the list directly.

### Tests
- Added 7 new test cases covering: URL path extraction, `_raw` fallback, multiple patterns in `_raw`, precedence behavior, empty data, and full pipeline integration.

## Behavior

| Scenario                              | Before                          | After                                |
| ---                                   | ---                             | ---                                  |
| Valid `url_path` with callback URL    | ✅ Extracts parent process name | ✅ Unchanged                         |
| `url_path` with local path / no UUIDs | ❌ Returns empty                | ✅ Falls back to `_raw` scan         |
| Both `url_path` and `_raw` present    | Uses `url_path`                 | ✅ `url_path` still takes precedence |
| No data in either field               | Returns empty                   | ✅ Unchanged                         |

## Screenshots
Log output:
<img width="2249" height="423" alt="image" src="https://github.com/user-attachments/assets/7eafa997-1668-49d6-85ad-1176792d4814" />

Ui output:
<img width="704" height="207" alt="image" src="https://github.com/user-attachments/assets/894aefaa-5efe-4107-a018-b71c0abd3e38" />


### Checklist

<!--
Please submit the source code in a way, where you could honestly say `This code is finished`.
If you feel that there are possibilities for improving the code quality, please do so.
By doing this, you are actively helping us to improve the quality of the entire OpenAEV project.
-->

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I wrote test cases for the relevant uses case
- [x] I added/update the relevant documentation (either on github or on notion)
- [x] Where necessary I refactored code to improve the overall quality
- [x] For bug fix -> I implemented a test that covers the bug

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR draft is open._ -->
<!-- For completed items, change [ ] to [x]. -->
