### PR TITLE
fix(splunk): Hardenning the _raw field (#489)

### DIFF
--- a/splunk-es/src/services/models.py
+++ b/splunk-es/src/services/models.py
@@ -132,8 +132,8 @@ class SplunkESResponse(BaseModel):
                 rule_name=raw_result.get("rule_name"),
                 event_type=raw_result.get("event_type"),
                 severity=raw_result.get("severity"),
-                _raw=raw_result,
             )
+            alert._raw = raw_result
             alerts.append(alert)
 
         return cls(results=alerts)

--- a/splunk-es/tests/services/test_models.py
+++ b/splunk-es/tests/services/test_models.py
@@ -1,0 +1,24 @@
+"""Behavior tests for Splunk ES response models."""
+
+from src.services.models import SplunkESResponse
+
+
+def test_raw_response_retains_the_original_result_row_on_the_alert():
+    """A parsed alert retains its complete source result for later processing."""
+    raw_result = {
+        "_time": "2026-08-28T10:42:17.000+00:00",
+        "host": "windows-endpoint-01",
+        "source": "WinEventLog:Security",
+        "sourcetype": "XmlWinEventLog:Security",
+        "EventCode": "4688",
+        "src": "192.0.2.25",
+        "dest": "198.51.100.40",
+        "process_name": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+        "parent_process_name": "C:\\Windows\\explorer.exe",
+        "severity": "high",
+    }
+    payload = {"preview": False, "offset": 0, "results": [raw_result]}
+
+    response = SplunkESResponse.from_raw_response(payload)
+
+    assert response.results[0]._raw == raw_result  # noqa: S101


### PR DESCRIPTION
## Summary

- Explicitly assign the Pydantic `PrivateAttr` after model construction.
- Add regression coverage for the `_raw` field.
- Keep the separate parent matcher out of scope.

## Checks

- Passed: isolated focused regression test.
- Passed: lint, format, and pre-commit checks.
- Blocked: full test invocations due to unavailable dependencies.
- Not clean: mypy reports existing failures in imported files unrelated to this change.