### PR TITLE
fix(sentinelone): add new endpoint SDL2 for saas, and fix logic for selfhosted drilldown (#490)

### DIFF
--- a/sentinelone/.dockerignore
+++ b/sentinelone/.dockerignore
@@ -9,3 +9,7 @@ __pycache__
 .ruff_cache
 .mypy_cache
 .pytest_cache
+
+# local test venvs
+.venv
+.venv-*

--- a/sentinelone/README.md
+++ b/sentinelone/README.md
@@ -158,7 +158,10 @@ On each run, the collector:
   - `GET /web/api/v2.1/threat-events` (fetch threat events for behavioral threats)
   - Deep Visibility (when enabled): `POST /web/api/v2.1/dv/init-query`, `GET /web/api/v2.1/dv/query-status`,
     `GET /web/api/v2.1/dv/events`
-  - Authentication uses the `Authorization: ApiToken <api_key>` header.
+  - Unified Alerts (SaaS, when `SENTINELONE_ENABLE_ALERTS` is enabled): `POST /web/api/v2.1/unifiedalerts/graphql`
+    (Singularity alerts). This surfaces behavioral / STAR / AI detections that never become Threats.
+  - Authentication uses `Authorization: ApiToken <api_key>` for the Threats / Deep Visibility endpoints and
+    `Authorization: Bearer <api_key>` for the SDL v2 and Unified Alerts (GraphQL) endpoints.
 - Reference: [SentinelOne API documentation](https://developer.sentinelone.com/reference)
 
 ## Debugging
@@ -172,6 +175,10 @@ static-engine detections that require Deep Visibility (Complete license).
 
 - The search window is anchored on the inject `end_date` and defaults to one hour; the collector is designed to validate
   expectations shortly after an inject runs, not to back-fill historical data.
+- SentinelOne exposes detections in two places: the Threats API (static-engine reputation hits and mitigated
+  behavioral threats) and Unified Alerts (behavioral / STAR / AI detections that never become Threats, e.g.
+  "Potential Mimikatz Execution"). With `SENTINELONE_ENABLE_ALERTS` (default on, SaaS only) the collector
+  correlates both, so a detection visible in the console as an alert is reflected in OpenAEV even without a Threat.
 - Static-engine (static AI) detections rely on Deep Visibility, which requires a Complete license; behavioral detections
   are validated on Core and Control licenses as well.
 - The required SentinelOne permissions and endpoints reflect the current implementation. SentinelOne may change its API

--- a/sentinelone/src/collector/models.py
+++ b/sentinelone/src/collector/models.py
@@ -144,6 +144,10 @@ class ExpectationResult(BaseModel):
 
     expectation_id: str = Field(..., description="ID of the processed expectation")
     is_valid: bool = Field(..., description="Whether the expectation was validated")
+    is_pending: bool = Field(
+        False,
+        description="Whether this result is held pending a transient fetch failure.",
+    )
     expectation: Any | None = Field(None, description="The original expectation object")
     matched_alerts: list[dict[str, Any]] | None = Field(
         None, description="List of alerts that matched this expectation"

--- a/sentinelone/src/models/configs/config_loader.py
+++ b/sentinelone/src/models/configs/config_loader.py
@@ -165,11 +165,15 @@ class ConfigLoader(ConfigBaseSettings):
                     "data": self.sentinelone.api_key.get_secret_value()
                 },
                 "sentinelone_time_window": {"data": self.sentinelone.time_window},
+                "sentinelone_retry_window": {"data": self.sentinelone.retry_window},
                 "sentinelone_expectation_batch_size": {
                     "data": self.sentinelone.expectation_batch_size
                 },
                 "sentinelone_enable_deep_visibility_search": {
                     "data": self.sentinelone.enable_deep_visibility_search
+                },
+                "sentinelone_deep_visibility_lookback": {
+                    "data": self.sentinelone.deep_visibility_lookback
                 },
                 "sentinelone_disable_strict_end_date": {
                     "data": self.sentinelone.disable_strict_end_date

--- a/sentinelone/src/models/configs/config_loader.py
+++ b/sentinelone/src/models/configs/config_loader.py
@@ -172,6 +172,9 @@ class ConfigLoader(ConfigBaseSettings):
                 "sentinelone_enable_deep_visibility_search": {
                     "data": self.sentinelone.enable_deep_visibility_search
                 },
+                "sentinelone_enable_alerts": {
+                    "data": self.sentinelone.enable_alerts
+                },
                 "sentinelone_deep_visibility_lookback": {
                     "data": self.sentinelone.deep_visibility_lookback
                 },

--- a/sentinelone/src/models/configs/config_loader.py
+++ b/sentinelone/src/models/configs/config_loader.py
@@ -172,9 +172,7 @@ class ConfigLoader(ConfigBaseSettings):
                 "sentinelone_enable_deep_visibility_search": {
                     "data": self.sentinelone.enable_deep_visibility_search
                 },
-                "sentinelone_enable_alerts": {
-                    "data": self.sentinelone.enable_alerts
-                },
+                "sentinelone_enable_alerts": {"data": self.sentinelone.enable_alerts},
                 "sentinelone_deep_visibility_lookback": {
                     "data": self.sentinelone.deep_visibility_lookback
                 },

--- a/sentinelone/src/models/configs/sentinelone_configs.py
+++ b/sentinelone/src/models/configs/sentinelone_configs.py
@@ -42,6 +42,17 @@ class _ConfigLoaderSentinelOne(ConfigBaseSettings):
         default=False,
         description="Enable deep visibility search for SentinelOne threat searches.",
     )
+    enable_alerts: bool = Field(
+        alias="SENTINELONE_ENABLE_ALERTS",
+        default=True,
+        description=(
+            "Also correlate SentinelOne Unified Alerts (Singularity alerts "
+            "GraphQL API), not only Threats. Behavioral / STAR / AI detections "
+            "(e.g. Potential Mimikatz Execution) surface as Unified Alerts and "
+            "never as Threats, so this is required to validate them. SaaS only; "
+            "ignored on self-hosted instances."
+        ),
+    )
     deep_visibility_lookback: timedelta = Field(
         alias="SENTINELONE_DEEP_VISIBILITY_LOOKBACK",
         default=timedelta(days=1),

--- a/sentinelone/src/models/configs/sentinelone_configs.py
+++ b/sentinelone/src/models/configs/sentinelone_configs.py
@@ -27,6 +27,11 @@ class _ConfigLoaderSentinelOne(ConfigBaseSettings):
         default=timedelta(hours=1),
         description="Time window for SentinelOne threat searches when no date signatures are provided (ISO 8601 format).",
     )
+    retry_window: timedelta = Field(
+        alias="SENTINELONE_RETRY_WINDOW",
+        default=timedelta(minutes=10),
+        description="How long after the first attempt an unresolved expectation is re-attempted on every collector cycle, before one final attempt emits the verdict (ISO 8601 format).",
+    )
     expectation_batch_size: int = Field(
         alias="SENTINELONE_EXPECTATION_BATCH_SIZE",
         default=50,
@@ -36,6 +41,18 @@ class _ConfigLoaderSentinelOne(ConfigBaseSettings):
         alias="SENTINELONE_ENABLE_DEEP_VISIBILITY_SEARCH",
         default=False,
         description="Enable deep visibility search for SentinelOne threat searches.",
+    )
+    deep_visibility_lookback: timedelta = Field(
+        alias="SENTINELONE_DEEP_VISIBILITY_LOOKBACK",
+        default=timedelta(days=1),
+        description=(
+            "Lookback window (ISO 8601 duration, e.g. PT1H / P1D) for the Deep "
+            "Visibility / SDL file-event pivot query. Decoupled from the threat "
+            "window: a file can be dropped or executed long before the alert that "
+            "references it is raised, so the event query pivots on the file SHA1 and "
+            "reaches back this far from now. Keep it within the account's Deep "
+            "Visibility retention (30/90/180/365 days)."
+        ),
     )
     disable_strict_end_date: bool = Field(
         alias="SENTINELONE_DISABLE_STRICT_END_DATE",

--- a/sentinelone/src/services/client_api.py
+++ b/sentinelone/src/services/client_api.py
@@ -4,11 +4,26 @@ import logging
 from datetime import timedelta
 
 import requests  # type: ignore[import-untyped]
+from requests.adapters import HTTPAdapter  # type: ignore[import-untyped]
+from urllib3.util.retry import Retry
 
 from ..models.configs.config_loader import ConfigLoader
 from .exception import SentinelOneSessionError
 
 LOG_PREFIX = "[SentinelOneClientAPI]"
+
+# Per-request timeout kept well below the 2-minute collection cycle so a
+# stalled connection degrades fast instead of stalling the cycle.
+REQUEST_TIMEOUT_SECONDS = 30
+
+# Bounded transport resilience: retry idempotent GET requests only, and only
+# on retryable transport/status conditions (429 and 5xx). Non-idempotent
+# methods are never retried; 4xx responses and other failures propagate
+# unchanged so typed error classification downstream stays intact.
+RETRY_ALLOWED_METHODS = frozenset({"GET"})
+RETRY_STATUS_FORCELIST = [429, 500, 502, 503, 504]
+RETRY_BACKOFF_FACTOR = 0.5
+RETRY_TOTAL = 3
 
 
 class SentinelOneClientAPI:
@@ -32,6 +47,9 @@ class SentinelOneClientAPI:
         self.api_key: str = config.sentinelone.api_key.get_secret_value()
 
         self.time_window: timedelta = config.sentinelone.time_window
+        self.deep_visibility_lookback: timedelta = (
+            config.sentinelone.deep_visibility_lookback
+        )
 
         try:
             self.session: requests.Session = self._create_session()
@@ -69,6 +87,17 @@ class SentinelOneClientAPI:
                     "Accept": "application/json",
                 }
             )
+
+            retry = Retry(
+                total=RETRY_TOTAL,
+                backoff_factor=RETRY_BACKOFF_FACTOR,
+                status_forcelist=RETRY_STATUS_FORCELIST,
+                allowed_methods=RETRY_ALLOWED_METHODS,
+                respect_retry_after_header=True,
+            )
+            adapter = HTTPAdapter(max_retries=retry)
+            session.mount("http://", adapter)
+            session.mount("https://", adapter)
 
             return session
         except Exception as e:
@@ -112,7 +141,7 @@ class SentinelOneClientAPI:
         """
         endpoint = f"{self.base_url}/web/api/v2.1/accounts"
         try:
-            response = self.session.get(endpoint)
+            response = self.session.get(endpoint, timeout=REQUEST_TIMEOUT_SECONDS)
             response.raise_for_status()
             accounts = response.json().get("data", [])
         except Exception as e:

--- a/sentinelone/src/services/client_api.py
+++ b/sentinelone/src/services/client_api.py
@@ -38,6 +38,8 @@ class SentinelOneClientAPI:
         except Exception as e:
             raise SentinelOneSessionError(f"Failed to create session: {e}") from e
 
+        self.is_self_hosted: bool | None = None
+
         self.logger.debug(
             f"{LOG_PREFIX} Initializing SentinelOne API client components..."
         )
@@ -45,6 +47,8 @@ class SentinelOneClientAPI:
         self.logger.info(
             f"{LOG_PREFIX} SentinelOne API client initialized successfully"
         )
+
+        self.detect_is_self_hosted()
 
     def _create_session(self) -> requests.Session:
         """Create and configure HTTP session for SentinelOne API.
@@ -69,3 +73,67 @@ class SentinelOneClientAPI:
             return session
         except Exception as e:
             raise SentinelOneSessionError(f"Failed to configure session: {e}") from e
+
+    def detect_is_self_hosted(self) -> bool:
+        """Resolve whether the SentinelOne instance is self-hosted.
+
+        Detection is fully automatic: the MGMT account listing endpoint is
+        probed to decide (SaaS accounts expose an accountType field,
+        self-hosted instances do not). The resolved boolean is cached on
+        the client instance, so the probe runs at most once per client and
+        services can read the result from the attribute.
+
+        Returns:
+            True if the instance is self-hosted, False if it is SaaS.
+
+        """
+        if self.is_self_hosted is not None:
+            return self.is_self_hosted
+
+        self.is_self_hosted = self._probe_self_hosted()
+        return self.is_self_hosted
+
+    def _probe_self_hosted(self) -> bool:
+        """Probe the MGMT account listing to detect SaaS vs self-hosted.
+
+        Calls the account listing endpoint the connector already uses
+        (GET {base_url}/web/api/v2.1/accounts). A successful response
+        containing at least one account object with an accountType field
+        identifies a SaaS instance (e.g. accountType=Trial); a successful
+        response without accountType identifies a self-hosted instance.
+        Any probe failure (HTTP error such as 404/401, network error,
+        malformed body) logs a warning and defaults to SaaS (False), so a
+        transient failure on a working instance never flips it to
+        self-hosted.
+
+        Returns:
+            True if the instance is self-hosted, False if it is SaaS.
+
+        """
+        endpoint = f"{self.base_url}/web/api/v2.1/accounts"
+        try:
+            response = self.session.get(endpoint)
+            response.raise_for_status()
+            accounts = response.json().get("data", [])
+        except Exception as e:
+            self.logger.warning(
+                f"{LOG_PREFIX} Self-hosted probe failed "
+                f"({type(e).__name__}: {e}); defaulting to SaaS "
+                "(is_self_hosted=False)"
+            )
+            return False
+
+        for account in accounts:
+            if isinstance(account, dict) and "accountType" in account:
+                self.logger.info(
+                    f"{LOG_PREFIX} SaaS detected "
+                    f"(accountType={account['accountType']}); "
+                    "is_self_hosted=False"
+                )
+                return False
+
+        self.logger.info(
+            f"{LOG_PREFIX} Self-hosted detected "
+            "(no accountType in account listing); is_self_hosted=True"
+        )
+        return True

--- a/sentinelone/src/services/expectation_service.py
+++ b/sentinelone/src/services/expectation_service.py
@@ -2,7 +2,7 @@
 
 import logging
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -11,10 +11,16 @@ from pyoaev.apis.inject_expectation.model.expectation import (
     PreventionExpectation,
 )
 from pyoaev.signatures.types import SignatureTypes
+from requests import exceptions as requests_exceptions
 
 from .client_api import SentinelOneClientAPI
 from .converter import SentinelOneConverter
-from .exception import SentinelOneAPIError, SentinelOneExpectationError
+from .exception import (
+    SentinelOneAPIError,
+    SentinelOneExpectationError,
+    SentinelOneNetworkError,
+    SentinelOneValidationError,
+)
 from .fetcher_deep_visibility import FetcherDeepVisibility
 from .fetcher_sdl import FetcherSDL
 from .fetcher_threat import FetcherThreat
@@ -30,6 +36,11 @@ class ExpectationResult(BaseModel):
 
     expectation_id: str = Field(..., description="ID of the processed expectation")
     is_valid: bool = Field(..., description="Whether the expectation was validated")
+    is_pending: bool = Field(
+        False,
+        description="Whether this result is held pending a transient fetch failure "
+        "(no verdict emitted this cycle; retried before degrading)",
+    )
     expectation: Any | None = Field(None, description="The original expectation object")
     matched_alerts: list[dict[str, Any]] | None = Field(
         None, description="List of alerts that matched this expectation"
@@ -67,6 +78,7 @@ class SentinelOneExpectationService:
             config.sentinelone.enable_deep_visibility_search
         )
         self.disable_strict_end_date = config.sentinelone.disable_strict_end_date
+        self.retry_window: timedelta = config.sentinelone.retry_window
 
         self.threat_fetcher: FetcherThreat = FetcherThreat(self.client_api)
         self.threat_events_fetcher: FetcherThreatEvents = FetcherThreatEvents(
@@ -81,11 +93,11 @@ class SentinelOneExpectationService:
             self.deep_visibility_fetcher = FetcherSDL(self.client_api)
             self.logger.debug(f"{LOG_PREFIX} Deep-search backend: SDL v2 (SaaS)")
 
-        self.failure_tracker: defaultdict = defaultdict(int)
-        self.max_failure = 5
+        self.first_attempt_at: dict[str, datetime] = {}
 
         self.logger.info(
-            f"{LOG_PREFIX} Service initialized with batch size: {self.batch_size}"
+            f"{LOG_PREFIX} Service initialized with batch size: {self.batch_size}, "
+            f"retry window: {self.retry_window}"
         )
 
     def get_supported_signatures(self) -> list[SignatureTypes]:
@@ -155,14 +167,27 @@ class SentinelOneExpectationService:
                     self.logger.error(
                         f"{LOG_PREFIX} Error processing batch {batch_idx}: {e}"
                     )
-                    error_results = [
-                        self._create_error_result_object(
-                            SentinelOneExpectationError(f"Batch processing error: {e}"),
-                            expectation,
+                    if self._classify_error(e) == "transient":
+                        self.logger.warning(
+                            f"{LOG_PREFIX} Batch {batch_idx}: transient transport failure; "
+                            f"holding {len(batch)} expectations pending (no verdict emitted)"
                         )
-                        for expectation in batch
-                    ]
-                    all_results.extend(error_results)
+                        pending_results = [
+                            self._make_pending_result(e, expectation)
+                            for expectation in batch
+                        ]
+                        batch_results = self._update_failures(pending_results)
+                    else:
+                        batch_results = [
+                            self._create_error_result_object(
+                                SentinelOneExpectationError(
+                                    f"Batch processing error: {e}"
+                                ),
+                                expectation,
+                            )
+                            for expectation in batch
+                        ]
+                    all_results.extend(batch_results)
 
             valid_count = sum(1 for r in all_results if r.is_valid)
             invalid_count = len(all_results) - valid_count
@@ -229,26 +254,47 @@ class SentinelOneExpectationService:
     def _update_failures(
         self, results: list[ExpectationResult]
     ) -> list[ExpectationResult]:
-        """Update the failure tracker and return the relevant results for further process"""
+        """Apply the retry-window rule and return the results to emit or keep.
+
+        Every expectation that has not been validated yet follows a single
+        time-based lifecycle, independent of the collector period:
+
+        - the first failed attempt opens a retry window anchored at that
+          moment and is held pending (no verdict emitted);
+        - while the elapsed time since the first attempt stays within
+          ``retry_window`` every failed attempt is held pending (no verdict,
+          the expectation is re-fetched on the next collector cycle);
+        - the first attempt after the window has elapsed is the final
+          attempt: its result survives so the verdict is emitted, and the
+          lifecycle closes.
+
+        A valid result closes the lifecycle as well.
+        """
+        now = self._now()
         retry_results = []
         for result in results:
-            if (
-                not result.is_valid
-                and self.failure_tracker[result.expectation_id] < self.max_failure
-            ):
-                self.failure_tracker[result.expectation_id] += 1
-                retry_results.append(result)
-            elif result.expectation_id in self.failure_tracker:
-                self.failure_tracker.pop(result.expectation_id, None)
+            if result.is_valid:
+                self.first_attempt_at.pop(result.expectation_id, None)
+            else:
+                first_attempt = self.first_attempt_at.get(result.expectation_id)
+                if first_attempt is None or now - first_attempt <= self.retry_window:
+                    self.first_attempt_at.setdefault(result.expectation_id, now)
+                    retry_results.append(result)
+                else:
+                    self.first_attempt_at.pop(result.expectation_id, None)
 
         results = [result for result in results if not result in retry_results]
         return results
 
+    def _now(self) -> datetime:
+        """Current UTC time; single clock seam for the retry-window rule."""
+        return datetime.now(timezone.utc)
+
     def _update_date_in_case_of_failures(self, batch):
-        """Update the dates of a batch if a tracked failed expectation is found in it"""
-        now = datetime.now(timezone.utc)
+        """Update the dates of a batch if a pending expectation is found in it"""
+        now = self._now()
         if any(
-            str(expectation.inject_expectation_id) in self.failure_tracker
+            str(expectation.inject_expectation_id) in self.first_attempt_at
             for expectation in batch
         ):
             for expectation in batch:
@@ -330,7 +376,7 @@ class SentinelOneExpectationService:
                             )
 
                     if unique_sha1s:
-                        start_time, end_time = self._get_fetch_time_window(batch)
+                        start_time, end_time = self._get_deep_visibility_fetch_window()
 
                         self.logger.debug(
                             f"{LOG_PREFIX} Batch {batch_idx}: Fetching DV events for {len(unique_sha1s)} unique SHA1s (from {len(threats)} threats) in single query for time window: {start_time} to {end_time}"
@@ -375,6 +421,12 @@ class SentinelOneExpectationService:
 
             return results
 
+        except (
+            SentinelOneAPIError,
+            SentinelOneNetworkError,
+            SentinelOneValidationError,
+        ):
+            raise
         except Exception as e:
             raise SentinelOneExpectationError(
                 f"Error processing batch {batch_idx}: {e}"
@@ -445,11 +497,13 @@ class SentinelOneExpectationService:
         self,
         batch: list[DetectionExpectation | PreventionExpectation] | None,
     ) -> tuple[datetime, datetime]:
-        """Compute the fetch time window for a batch of expectations.
+        """Compute the fetch time window for the alert (threat) query.
 
-        The window end comes from the end_date signature (or now if absent).
-        The window start is the start_date signature when present and not after
-        end; otherwise it falls back to end minus SENTINELONE_TIME_WINDOW.
+        The window ends at the current time. It starts at the start_date
+        signature when present and not in the future; otherwise it falls back
+        to now minus SENTINELONE_TIME_WINDOW. The signature end date does not
+        anchor this window: the DV event window is decoupled and uses its own
+        fixed lookback (see ``_get_deep_visibility_fetch_window``).
 
         Args:
             batch: Optional batch of expectations to extract date filters from.
@@ -458,13 +512,38 @@ class SentinelOneExpectationService:
             Tuple of (start_time, end_time).
 
         """
-        end_time = self._extract_end_date_from_batch(batch)
-        if end_time is None:
-            end_time = datetime.now(timezone.utc)
+        end_time = datetime.now(timezone.utc)
 
         start_time = self._extract_start_date_from_batch(batch)
         if start_time is None or start_time > end_time:
             start_time = end_time - self.client_api.time_window
+
+        return start_time, end_time
+
+    def _get_deep_visibility_fetch_window(
+        self,
+        now: datetime | None = None,
+    ) -> tuple[datetime, datetime]:
+        """Compute the fetch window for the Deep Visibility / SDL file-event
+        pivot query.
+
+        Unlike the threat window (which is anchored to the expectation
+        start_date / alert time), this window ignores the signature dates
+        entirely. The event query pivots on the file SHA1 — a strong
+        selector — so the window only needs to be wide enough to reach a
+        file that may have been dropped or executed long before the alert
+        that references it. It therefore spans
+        ``[now - deep_visibility_lookback, now]``.
+
+        Args:
+            now: Reference end time (defaults to the current UTC time).
+
+        Returns:
+            Tuple of (start_time, end_time).
+
+        """
+        end_time = now or datetime.now(timezone.utc)
+        start_time = end_time - self.client_api.deep_visibility_lookback
 
         return start_time, end_time
 
@@ -481,6 +560,8 @@ class SentinelOneExpectationService:
 
         Raises:
             SentinelOneAPIError: If API call fails.
+            SentinelOneNetworkError: If a network/transport failure occurs.
+            SentinelOneValidationError: If request parameters are invalid.
 
         """
         try:
@@ -496,6 +577,12 @@ class SentinelOneExpectationService:
                 limit=1000,
             )
 
+        except (
+            SentinelOneAPIError,
+            SentinelOneNetworkError,
+            SentinelOneValidationError,
+        ):
+            raise
         except Exception as e:
             raise SentinelOneAPIError(
                 f"Error fetching threats for time window: {e}"
@@ -692,6 +779,13 @@ class SentinelOneExpectationService:
             )
 
             for sig_type, signatures in signature_groups.items():
+                if sig_type not in filtered_oaev_data:
+                    self.logger.debug(
+                        f"{LOG_PREFIX} Required signature data '{sig_type}' is absent "
+                        f"for threat {threat.threat_id}; expectation does not match"
+                    )
+                    return False
+
                 filtered_data = {sig_type: filtered_oaev_data[sig_type]}
                 self.logger.debug(
                     f"{LOG_PREFIX} Detection helper input - sig_type: {sig_type}"
@@ -727,6 +821,75 @@ class SentinelOneExpectationService:
                 f"{LOG_PREFIX} Error in expectation matching: {type(e)} - {e}"
             )
             return False
+
+    def _classify_error(self, error: Exception) -> str:
+        """Classify a batch-processing failure as "transient" or "permanent".
+
+        Transient failures (network drops, timeouts, 5xx, 408/429) are retryable:
+        the expectation is held pending and re-fetched on the next cycle instead
+        of emitting a verdict. Permanent failures (input validation, other 4xx)
+        and unrecognised errors keep the previous behaviour: a negative error
+        result.
+
+        Args:
+            error: The exception raised while processing the batch.
+
+        Returns:
+            "transient" or "permanent".
+
+        """
+        if isinstance(error, SentinelOneNetworkError):
+            return "transient"
+        if isinstance(error, SentinelOneValidationError):
+            return "permanent"
+
+        cause = error.__cause__
+        if isinstance(cause, requests_exceptions.HTTPError):
+            status = getattr(getattr(cause, "response", None), "status_code", None)
+            if status in (408, 429) or (status is not None and 500 <= status < 600):
+                return "transient"
+            if status is not None and 400 <= status < 500:
+                return "permanent"
+            return "transient"
+        if isinstance(
+            cause, (requests_exceptions.ConnectionError, requests_exceptions.Timeout)
+        ):
+            return "transient"
+
+        return "permanent"
+
+    def _make_pending_result(
+        self,
+        error: Exception,
+        expectation: DetectionExpectation | PreventionExpectation,
+    ) -> ExpectationResult:
+        """Create a pending result for a transient fetch failure.
+
+        The result is marked ``is_valid=False`` and ``is_pending=True`` and is
+        passed through ``_update_failures``: while the time since the first
+        attempt is within ``retry_window`` the result is removed (no verdict
+        emitted this cycle, the expectation is re-fetched next cycle); once
+        the window has elapsed the result survives on the final attempt and
+        degrades to a negative verdict instead of hanging forever.
+
+        Args:
+            error: The transient error that occurred.
+            expectation: The expectation to hold pending.
+
+        Returns:
+            ExpectationResult object with ``is_valid=False`` and
+            ``is_pending=True``.
+
+        """
+        return ExpectationResult(
+            expectation_id=str(expectation.inject_expectation_id),
+            is_valid=False,
+            is_pending=True,
+            expectation=expectation,
+            matched_alerts=None,
+            error_message=f"Transient fetch failure (pending, will retry): {error}",
+            processing_time=None,
+        )
 
     def _create_error_result_object(
         self,

--- a/sentinelone/src/services/expectation_service.py
+++ b/sentinelone/src/services/expectation_service.py
@@ -324,10 +324,7 @@ class SentinelOneExpectationService:
                             )
 
                     if unique_sha1s:
-                        end_time = self._extract_end_date_from_batch(batch)
-                        if end_time is None:
-                            end_time = datetime.now(timezone.utc)
-                        start_time = end_time - self.client_api.time_window
+                        start_time, end_time = self._get_fetch_time_window(batch)
 
                         self.logger.debug(
                             f"{LOG_PREFIX} Batch {batch_idx}: Fetching DV events for {len(unique_sha1s)} unique SHA1s (from {len(threats)} threats) in single query for time window: {start_time} to {end_time}"
@@ -420,9 +417,50 @@ class SentinelOneExpectationService:
         end_date = SignatureExtractor.extract_end_date(batch)
         if end_date:
             self.logger.debug(
-                f"{LOG_PREFIX} Extracted end_date from signatures: {end_date}, start_date will be calculated from time_window"
+                f"{LOG_PREFIX} Extracted end_date from signatures: {end_date}"
             )
         return end_date
+
+    def _extract_start_date_from_batch(
+        self, batch: list[DetectionExpectation | PreventionExpectation] | None = None
+    ) -> datetime | None:
+        """Extract start_date from batch signatures.
+
+        Args:
+            batch: Batch of expectations to extract start_date from.
+
+        Returns:
+            start_date as datetime or None if no valid start_date signature found.
+
+        """
+        return SignatureExtractor.extract_start_date(batch)
+
+    def _get_fetch_time_window(
+        self,
+        batch: list[DetectionExpectation | PreventionExpectation] | None,
+    ) -> tuple[datetime, datetime]:
+        """Compute the fetch time window for a batch of expectations.
+
+        The window end comes from the end_date signature (or now if absent).
+        The window start is the start_date signature when present and not after
+        end; otherwise it falls back to end minus SENTINELONE_TIME_WINDOW.
+
+        Args:
+            batch: Optional batch of expectations to extract date filters from.
+
+        Returns:
+            Tuple of (start_time, end_time).
+
+        """
+        end_time = self._extract_end_date_from_batch(batch)
+        if end_time is None:
+            end_time = datetime.now(timezone.utc)
+
+        start_time = self._extract_start_date_from_batch(batch)
+        if start_time is None or start_time > end_time:
+            start_time = end_time - self.client_api.time_window
+
+        return start_time, end_time
 
     def _fetch_threats_for_time_window(
         self, batch: list[DetectionExpectation | PreventionExpectation] | None = None
@@ -440,12 +478,7 @@ class SentinelOneExpectationService:
 
         """
         try:
-            end_time = self._extract_end_date_from_batch(batch)
-
-            if end_time is None:
-                end_time = datetime.now(timezone.utc)
-
-            start_time = end_time - self.client_api.time_window
+            start_time, end_time = self._get_fetch_time_window(batch)
 
             self.logger.debug(
                 f"{LOG_PREFIX} Delegating threat fetching to FetcherThreat for time window: {start_time} to {end_time}"

--- a/sentinelone/src/services/expectation_service.py
+++ b/sentinelone/src/services/expectation_service.py
@@ -852,7 +852,12 @@ class SentinelOneExpectationService:
                 return "permanent"
             return "transient"
         if isinstance(
-            cause, (requests_exceptions.ConnectionError, requests_exceptions.Timeout)
+            cause,
+            (
+                requests_exceptions.ConnectionError,
+                requests_exceptions.Timeout,
+                requests_exceptions.RetryError,
+            ),
         ):
             return "transient"
 

--- a/sentinelone/src/services/expectation_service.py
+++ b/sentinelone/src/services/expectation_service.py
@@ -16,6 +16,7 @@ from .client_api import SentinelOneClientAPI
 from .converter import SentinelOneConverter
 from .exception import SentinelOneAPIError, SentinelOneExpectationError
 from .fetcher_deep_visibility import FetcherDeepVisibility
+from .fetcher_sdl import FetcherSDL
 from .fetcher_threat import FetcherThreat
 from .fetcher_threat_events import FetcherThreatEvents
 from .model_threat import SentinelOneThreat
@@ -71,9 +72,14 @@ class SentinelOneExpectationService:
         self.threat_events_fetcher: FetcherThreatEvents = FetcherThreatEvents(
             self.client_api
         )
-        self.deep_visibility_fetcher: FetcherDeepVisibility = FetcherDeepVisibility(
-            self.client_api
-        )
+        if self.client_api.is_self_hosted:
+            self.deep_visibility_fetcher: FetcherDeepVisibility | FetcherSDL = (
+                FetcherDeepVisibility(self.client_api)
+            )
+            self.logger.debug(f"{LOG_PREFIX} Deep-search backend: DV 1.0 (self-hosted)")
+        else:
+            self.deep_visibility_fetcher = FetcherSDL(self.client_api)
+            self.logger.debug(f"{LOG_PREFIX} Deep-search backend: SDL v2 (SaaS)")
 
         self.failure_tracker: defaultdict = defaultdict(int)
         self.max_failure = 5

--- a/sentinelone/src/services/expectation_service.py
+++ b/sentinelone/src/services/expectation_service.py
@@ -25,6 +25,7 @@ from .fetcher_deep_visibility import FetcherDeepVisibility
 from .fetcher_sdl import FetcherSDL
 from .fetcher_threat import FetcherThreat
 from .fetcher_threat_events import FetcherThreatEvents
+from .fetcher_unified_alerts import FetcherUnifiedAlerts
 from .model_threat import SentinelOneThreat
 from .utils import SignatureExtractor, TraceBuilder
 
@@ -78,6 +79,7 @@ class SentinelOneExpectationService:
             config.sentinelone.enable_deep_visibility_search
         )
         self.disable_strict_end_date = config.sentinelone.disable_strict_end_date
+        self.enable_alerts = config.sentinelone.enable_alerts
         self.retry_window: timedelta = config.sentinelone.retry_window
 
         self.threat_fetcher: FetcherThreat = FetcherThreat(self.client_api)
@@ -92,6 +94,20 @@ class SentinelOneExpectationService:
         else:
             self.deep_visibility_fetcher = FetcherSDL(self.client_api)
             self.logger.debug(f"{LOG_PREFIX} Deep-search backend: SDL v2 (SaaS)")
+
+        # Unified Alerts (Singularity alerts GraphQL) carry the behavioral / STAR
+        # / AI detections that never become Threats. SaaS only; on self-hosted the
+        # endpoint is absent, so the correlation is skipped.
+        self.alerts_fetcher: FetcherUnifiedAlerts | None = None
+        if self.enable_alerts and not self.client_api.is_self_hosted:
+            self.alerts_fetcher = FetcherUnifiedAlerts(self.client_api)
+            self.logger.debug(f"{LOG_PREFIX} Unified Alerts correlation: enabled (SaaS)")
+        else:
+            self.logger.debug(
+                f"{LOG_PREFIX} Unified Alerts correlation: disabled "
+                f"(enable_alerts={self.enable_alerts}, "
+                f"self_hosted={self.client_api.is_self_hosted})"
+            )
 
         self.first_attempt_at: dict[str, datetime] = {}
 
@@ -412,6 +428,30 @@ class SentinelOneExpectationService:
                 except Exception as e:
                     self.logger.error(
                         f"{LOG_PREFIX} Batch {batch_idx}: Error fetching DV events for threats batch: {e}"
+                    )
+
+            # Correlate SentinelOne Unified Alerts (behavioral / STAR / AI
+            # detections that never become Threats). Additive and isolated:
+            # an alerts failure must never break the Threats verdict, so it is
+            # caught here rather than propagated to the batch retry logic.
+            if self.alerts_fetcher is not None:
+                try:
+                    alert_start, alert_end = self._get_fetch_time_window(batch)
+                    alert_threats, alert_events = (
+                        self.alerts_fetcher.fetch_alert_threats(alert_start, alert_end)
+                    )
+                    if alert_threats:
+                        threats = threats + alert_threats
+                        for alert_id, events in alert_events.items():
+                            threat_events[alert_id].extend(events)
+                        self.logger.info(
+                            f"{LOG_PREFIX} Batch {batch_idx}: added "
+                            f"{len(alert_threats)} unified alerts to the "
+                            f"{len(threats) - len(alert_threats)} threats"
+                        )
+                except Exception as e:
+                    self.logger.error(
+                        f"{LOG_PREFIX} Batch {batch_idx}: Error fetching unified alerts: {e}"
                     )
 
             results = self._match_threats_to_expectations(

--- a/sentinelone/src/services/expectation_service.py
+++ b/sentinelone/src/services/expectation_service.py
@@ -101,7 +101,9 @@ class SentinelOneExpectationService:
         self.alerts_fetcher: FetcherUnifiedAlerts | None = None
         if self.enable_alerts and not self.client_api.is_self_hosted:
             self.alerts_fetcher = FetcherUnifiedAlerts(self.client_api)
-            self.logger.debug(f"{LOG_PREFIX} Unified Alerts correlation: enabled (SaaS)")
+            self.logger.debug(
+                f"{LOG_PREFIX} Unified Alerts correlation: enabled (SaaS)"
+            )
         else:
             self.logger.debug(
                 f"{LOG_PREFIX} Unified Alerts correlation: disabled "

--- a/sentinelone/src/services/fetcher_sdl.py
+++ b/sentinelone/src/services/fetcher_sdl.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+from collections.abc import Mapping
 from datetime import datetime, timezone
 from typing import Any
 
@@ -582,7 +583,7 @@ class FetcherSDL:
 
         """
         headers = getattr(response, "headers", None)
-        if not isinstance(headers, dict):
+        if not isinstance(headers, Mapping):
             return None
         for key, value in headers.items():
             if key.lower() == FORWARD_TAG_HEADER:
@@ -612,6 +613,10 @@ class FetcherSDL:
                 exhausted.
 
         """
+        headers = dict(extra_kwargs.get("headers") or {})
+        headers["Authorization"] = f"Bearer {self.client_api.api_key}"
+        extra_kwargs["headers"] = headers
+
         attempt = 0
         while True:
             try:

--- a/sentinelone/src/services/fetcher_sdl.py
+++ b/sentinelone/src/services/fetcher_sdl.py
@@ -1,0 +1,814 @@
+"""SentinelOne SDL v2 deep-search fetcher for SaaS instances."""
+
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from requests import ConnectionError, RequestException, Timeout
+
+from .client_api import SentinelOneClientAPI
+from .exception import (
+    SentinelOneAPIError,
+    SentinelOneNetworkError,
+    SentinelOneValidationError,
+)
+
+LOG_PREFIX = "[FetcherSDL]"
+REQUEST_TIMEOUT_SECONDS = 30
+PAGE_LIMIT = 100
+MAX_PAGES = 200
+MAX_POLL_ATTEMPTS = 30
+POLL_INTERVAL_SECONDS = 2
+MAX_RATE_LIMIT_RETRIES = 4
+FORWARD_TAG_HEADER = "x-dataset-query-forward-tag"
+S1QL_BASE_FILTER = "dataSource.name='SentinelOne' dataSource.category='security'"
+
+
+class FetcherSDL:
+    """Fetcher for SentinelOne SDL v2 deep-search (SaaS) events by file SHA1."""
+
+    def __init__(self, client_api: SentinelOneClientAPI):
+        """Initialize the SDL v2 fetcher.
+
+        Args:
+            client_api: SentinelOne API client instance.
+
+        """
+        self.client_api = client_api
+        self.logger = logging.getLogger(__name__)
+
+    def fetch_events_for_sha1(
+        self, sha1: str, start_time: datetime = None, end_time: datetime = None
+    ) -> list[dict[str, Any]]:
+        """Fetch SDL v2 deep-search events for a specific SHA1.
+
+        Args:
+            sha1: SHA1 hash to search for.
+            start_time: Start time for the search (optional).
+            end_time: End time for the search (optional).
+
+        Returns:
+            List of event dictionaries compatible with threat events.
+
+        Raises:
+            SentinelOneValidationError: If SHA1 is invalid.
+            SentinelOneAPIError: If API call fails.
+            SentinelOneNetworkError: If network error occurs.
+
+        """
+        if not sha1 or not isinstance(sha1, str):
+            raise SentinelOneValidationError("SHA1 must be a non-empty string")
+
+        try:
+            start_time, end_time = self._resolve_time_window(start_time, end_time)
+            s1ql_filter = self._build_s1ql_filter([sha1])
+
+            self.logger.debug(f"{LOG_PREFIX} Fetching SDL events for SHA1: {sha1}")
+            self.logger.debug(f"{LOG_PREFIX} S1QL filter: {s1ql_filter}")
+
+            rows = self._fetch_all_rows(s1ql_filter, start_time, end_time)
+
+            events = [self._map_row_to_event(row) for row in rows]
+            events = [event for event in events if event.get("fileSha1") == sha1]
+
+            self.logger.info(
+                f"{LOG_PREFIX} Successfully fetched {len(events)} SDL events for SHA1: {sha1}"
+            )
+            return events
+
+        except (
+            SentinelOneValidationError,
+            SentinelOneAPIError,
+            SentinelOneNetworkError,
+        ):
+            raise
+        except Exception as e:
+            raise SentinelOneAPIError(
+                f"Unexpected error fetching SDL events for SHA1 {sha1}: {e}"
+            ) from e
+
+    def fetch_events_for_batch_sha1(
+        self,
+        sha1_list: list[str],
+        start_time: datetime = None,
+        end_time: datetime = None,
+    ) -> dict[str, list[dict[str, Any]]]:
+        """Fetch SDL v2 deep-search events for multiple SHA1s in a single query.
+
+        Args:
+            sha1_list: List of SHA1 hashes to search for.
+            start_time: Start time for the search (optional).
+            end_time: End time for the search (optional).
+
+        Returns:
+            Dictionary mapping each valid SHA1 to its list of event
+            dictionaries. Requested SHA1s with no matches map to an empty
+            list; rows whose file SHA1 is not in the requested list are
+            dropped.
+
+        Raises:
+            SentinelOneValidationError: If SHA1 list is invalid.
+            SentinelOneAPIError: If API call fails.
+            SentinelOneNetworkError: If network error occurs.
+
+        """
+        if not sha1_list or not isinstance(sha1_list, list):
+            raise SentinelOneValidationError("sha1_list must be a non-empty list")
+
+        valid_sha1s = [sha1 for sha1 in sha1_list if sha1 and isinstance(sha1, str)]
+
+        if not valid_sha1s:
+            self.logger.debug(f"{LOG_PREFIX} No valid SHA1s provided")
+            return {}
+
+        try:
+            start_time, end_time = self._resolve_time_window(start_time, end_time)
+            s1ql_filter = self._build_s1ql_filter(valid_sha1s)
+
+            self.logger.debug(
+                f"{LOG_PREFIX} Fetching SDL events for {len(valid_sha1s)} SHA1s in batch"
+            )
+            self.logger.debug(f"{LOG_PREFIX} S1QL filter: {s1ql_filter}")
+
+            rows = self._fetch_all_rows(s1ql_filter, start_time, end_time)
+
+            sha1_to_events: dict[str, list[dict[str, Any]]] = {
+                sha1: [] for sha1 in valid_sha1s
+            }
+
+            for row in rows:
+                event = self._map_row_to_event(row)
+                file_sha1 = event.get("fileSha1")
+                if file_sha1 in sha1_to_events:
+                    sha1_to_events[file_sha1].append(event)
+
+            total_events = sum(len(events) for events in sha1_to_events.values())
+            self.logger.info(
+                f"{LOG_PREFIX} Successfully fetched {total_events} total SDL events for {len(valid_sha1s)} SHA1s"
+            )
+            return sha1_to_events
+
+        except (
+            SentinelOneValidationError,
+            SentinelOneAPIError,
+            SentinelOneNetworkError,
+        ):
+            raise
+        except Exception as e:
+            raise SentinelOneAPIError(
+                f"Unexpected error fetching SDL events for batch SHA1s: {e}"
+            ) from e
+
+    def _resolve_time_window(
+        self, start_time: datetime | None, end_time: datetime | None
+    ) -> tuple[datetime, datetime]:
+        """Resolve the search window, defaulting to the configured time window.
+
+        Args:
+            start_time: Optional explicit start.
+            end_time: Optional explicit end.
+
+        Returns:
+            Resolved (start_time, end_time) tuple.
+
+        """
+        if end_time is None:
+            end_time = datetime.now(timezone.utc)
+        if start_time is None:
+            start_time = end_time - self.client_api.time_window
+        return start_time, end_time
+
+    def _build_s1ql_filter(self, sha1_list: list[str]) -> str:
+        """Build the tenant-wide S1QL 2.0 filter for the given SHA1s.
+
+        The filter is scoped to SentinelOne security events and matches
+        tgt.file.sha1 exactly; no 1.0 field names are used.
+
+        Args:
+            sha1_list: SHA1 hashes to search for.
+
+        Returns:
+            S1QL 2.0 filter expression string.
+
+        """
+        escaped = [self._escape_s1ql_string(sha1) for sha1 in sha1_list]
+        if len(escaped) == 1:
+            return f"{S1QL_BASE_FILTER} tgt.file.sha1='{escaped[0]}'"
+        or_expression = " or ".join(f"tgt.file.sha1='{sha1}'" for sha1 in escaped)
+        return f"{S1QL_BASE_FILTER} ({or_expression})"
+
+    def _escape_s1ql_string(self, value: str) -> str:
+        """Escape a value for embedding in an S1QL single-quoted string.
+
+        Args:
+            value: Raw value to escape.
+
+        Returns:
+            Value with backslashes escaped before quotes.
+
+        """
+        return value.replace("\\", "\\\\").replace("'", "\\'")
+
+    def _build_launch_body(
+        self,
+        s1ql_filter: str,
+        start_time: datetime,
+        end_time: datetime,
+        cursor: str | None,
+    ) -> dict:
+        """Build the SDL v2 query launch request body.
+
+        Only filter, limit, and cursor are valid log block fields; offset
+        and lastCursor are not part of the SDL v2 contract.
+
+        Args:
+            s1ql_filter: S1QL 2.0 filter expression.
+            start_time: Window start.
+            end_time: Window end.
+            cursor: Resumption cursor (None on the first page).
+
+        Returns:
+            JSON-ready launch body.
+
+        """
+        log_block: dict = {"filter": s1ql_filter, "limit": PAGE_LIMIT}
+        if cursor:
+            log_block["cursor"] = cursor
+
+        return {
+            "queryType": "LOG",
+            "tenant": True,
+            "startTime": self._format_timestamp(start_time),
+            "endTime": self._format_timestamp(end_time),
+            "queryPriority": "HIGH",
+            "log": log_block,
+        }
+
+    def _fetch_all_rows(
+        self,
+        s1ql_filter: str,
+        start_time: datetime,
+        end_time: datetime,
+    ) -> list[dict[str, Any]]:
+        """Fetch all matching rows by paging the SDL v2 query.
+
+        Page 1 is launched without a cursor; each later page resumes with
+        the cursor of the previous page's last row. Resumption is
+        inclusive, so rows are deduplicated by cursor (falling back to
+        event.id). Paging stops when the first page's estimatedMatchCount
+        is reached, when a page yields no new rows, when a short page
+        exhausts its estimate, or at the defensive page cap.
+
+        Args:
+            s1ql_filter: S1QL 2.0 filter expression.
+            start_time: Resolved window start.
+            end_time: Resolved window end.
+
+        Returns:
+            List of unique raw row dictionaries in fetch order.
+
+        Raises:
+            SentinelOneAPIError: If any launch or poll fails.
+            SentinelOneNetworkError: If a network error occurs.
+
+        """
+        unique_rows: list[dict[str, Any]] = []
+        seen_keys: set = set()
+        est_total: Any = None
+        cursor: str | None = None
+
+        for page_number in range(1, MAX_PAGES + 1):
+            body = self._build_launch_body(s1ql_filter, start_time, end_time, cursor)
+            query_id, forward_tag = self._launch_query(body)
+            final_body = self._poll_query_to_completion(query_id, forward_tag)
+
+            data = self._extract_page_data(final_body)
+            page_est = data.get("estimatedMatchCount")
+            rows = data.get("matches") or []
+            if page_number == 1:
+                est_total = page_est
+
+            new_rows = self._collect_new_rows(rows, seen_keys)
+            unique_rows.extend(new_rows)
+
+            if self._should_stop_pagination(
+                est_total, len(unique_rows), new_rows, rows, page_est
+            ):
+                break
+
+            cursor = self._next_cursor(rows)
+            if cursor is None:
+                break
+        else:
+            self.logger.warning(
+                f"{LOG_PREFIX} Reached the maximum of {MAX_PAGES} pages; "
+                f"returning {len(unique_rows)} unique rows"
+            )
+
+        return unique_rows
+
+    def _collect_new_rows(self, rows: list, seen_keys: set) -> list:
+        """Filter out rows already seen, keying on cursor then event.id.
+
+        Args:
+            rows: Rows of the current page.
+            seen_keys: Set of dedupe keys observed so far.
+
+        Returns:
+            Only the rows whose key was not seen before.
+
+        """
+        new_rows = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            key = self._row_dedupe_key(row)
+            if key is None or key in seen_keys:
+                continue
+            seen_keys.add(key)
+            new_rows.append(row)
+        return new_rows
+
+    def _row_dedupe_key(self, row: dict) -> Any:
+        """Compute the dedupe key for a row.
+
+        Args:
+            row: Raw SDL match row.
+
+        Returns:
+            The row cursor, or the event.id as fallback, or None.
+
+        """
+        key = row.get("cursor")
+        if key:
+            return key
+        values = row.get("values")
+        if isinstance(values, dict):
+            return values.get("event.id")
+        return None
+
+    def _should_stop_pagination(
+        self,
+        est_total: Any,
+        unique_count: int,
+        new_rows: list,
+        page_rows: list,
+        page_est: Any,
+    ) -> bool:
+        """Decide whether paging should stop after the current page.
+
+        Args:
+            est_total: estimatedMatchCount reported by the first page.
+            unique_count: Unique rows collected so far (after this page).
+            new_rows: New rows contributed by the current page.
+            page_rows: All rows of the current page.
+            page_est: estimatedMatchCount reported by the current page.
+
+        Returns:
+            True when all matches are accounted for or no more pages can
+            contribute new rows.
+
+        """
+        if est_total is not None and unique_count >= est_total:
+            return True
+        if not new_rows:
+            return True
+        if (
+            len(page_rows) < PAGE_LIMIT
+            and page_est is not None
+            and page_est <= len(page_rows)
+        ):
+            return True
+        return False
+
+    def _next_cursor(self, rows: list) -> str | None:
+        """Get the cursor to resume with after the current page.
+
+        Args:
+            rows: Rows of the current page (may be empty).
+
+        Returns:
+            The last row's cursor, or None when there is none.
+
+        """
+        if not rows or not isinstance(rows[-1], dict):
+            return None
+        return rows[-1].get("cursor")
+
+    def _extract_page_data(self, final_body: Any) -> dict:
+        """Extract the data block from a query response body.
+
+        Args:
+            final_body: Query response body (may be malformed).
+
+        Returns:
+            The data dict, or an empty dict when absent.
+
+        """
+        if not isinstance(final_body, dict):
+            return {}
+        data = final_body.get("data")
+        return data if isinstance(data, dict) else {}
+
+    def _launch_query(self, body: dict) -> tuple[str, str | None]:
+        """Launch a SDL v2 long-running query.
+
+        Args:
+            body: Full launch request body.
+
+        Returns:
+            Tuple of (query_id, forward_tag) where forward_tag may be None.
+
+        Raises:
+            SentinelOneAPIError: If the launch fails or returns no query id.
+            SentinelOneNetworkError: If a network error occurs.
+
+        """
+        endpoint = f"{self.client_api.base_url}/sdl/v2/api/queries"
+        self.logger.debug(f"{LOG_PREFIX} Launching SDL query: POST {endpoint}")
+
+        response = self._send_with_rate_limit_retry(
+            "post", endpoint, json=body, timeout=REQUEST_TIMEOUT_SECONDS
+        )
+
+        if response.status_code != 200:
+            self._raise_for_error_response(response, "SDL query launch")
+
+        json_data = response.json()
+        if not isinstance(json_data, dict):
+            raise SentinelOneAPIError(
+                f"SDL query launch returned a non-JSON body: {str(json_data)[:200]}"
+            )
+
+        query_id = json_data.get("id")
+        if not query_id:
+            raise SentinelOneAPIError("SDL query launch response is missing query id")
+
+        return query_id, self._extract_forward_tag(response)
+
+    def _poll_query_to_completion(self, query_id: str, forward_tag: str | None) -> dict:
+        """Poll a SDL v2 query until it reports all steps completed.
+
+        Every poll GETs /sdl/v2/api/queries/{id} with lastStepSeen set to
+        the last observed stepsCompleted, and echoes the forward tag
+        header received at launch. A 404 means the query expired.
+
+        Args:
+            query_id: Identifier returned by the launch call.
+            forward_tag: Query forward tag to echo on every poll.
+
+        Returns:
+            Final query response body (dict).
+
+        Raises:
+            SentinelOneAPIError: If polling fails, the query expired, or
+                it did not complete within MAX_POLL_ATTEMPTS polls.
+            SentinelOneNetworkError: If a network error occurs.
+
+        """
+        endpoint = f"{self.client_api.base_url}/sdl/v2/api/queries/{query_id}"
+        headers = self._forward_tag_headers(forward_tag)
+        last_seen = 0
+
+        for _attempt in range(MAX_POLL_ATTEMPTS):
+            params = {"lastStepSeen": last_seen}
+            self.logger.debug(
+                f"{LOG_PREFIX} Polling SDL query {query_id} (lastStepSeen={last_seen})"
+            )
+
+            response = self._send_with_rate_limit_retry(
+                "get",
+                endpoint,
+                params=params,
+                headers=headers,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+
+            if response.status_code != 200:
+                if response.status_code == 404:
+                    raise SentinelOneAPIError(
+                        f"SDL query {query_id} expired (HTTP 404): "
+                        f"{self._parse_error_response(response)}"
+                    )
+                self._raise_for_error_response(response, "SDL query poll")
+
+            json_data = response.json()
+            if not isinstance(json_data, dict):
+                raise SentinelOneAPIError(
+                    f"SDL query poll returned a non-JSON body: {str(json_data)[:200]}"
+                )
+
+            steps_completed, steps_total = self._extract_progress(json_data)
+            if steps_completed is not None:
+                last_seen = steps_completed
+
+            if self._is_query_complete(steps_completed, steps_total):
+                self.logger.info(
+                    f"{LOG_PREFIX} SDL query {query_id} completed "
+                    f"(steps {steps_completed}/{steps_total})"
+                )
+                return json_data
+
+            time.sleep(POLL_INTERVAL_SECONDS)
+
+        raise SentinelOneAPIError(
+            f"SDL query {query_id} did not complete within {MAX_POLL_ATTEMPTS} polls"
+        )
+
+    def _extract_progress(self, json_data: dict) -> tuple[int | None, int | None]:
+        """Extract stepsCompleted/stepsTotal, preferring the top level.
+
+        Args:
+            json_data: Query response body.
+
+        Returns:
+            Tuple of (steps_completed, steps_total); either may be None.
+
+        """
+        data = json_data.get("data")
+        if not isinstance(data, dict):
+            data = {}
+
+        steps_completed = json_data.get("stepsCompleted", data.get("stepsCompleted"))
+        steps_total = json_data.get("stepsTotal", data.get("stepsTotal"))
+        return steps_completed, steps_total
+
+    def _is_query_complete(
+        self, steps_completed: int | None, steps_total: int | None
+    ) -> bool:
+        """Check whether the query reports all steps completed.
+
+        Args:
+            steps_completed: Steps completed so far (may be None).
+            steps_total: Total steps (may be None).
+
+        Returns:
+            True when stepsTotal is positive and stepsCompleted reached it.
+
+        """
+        return (
+            steps_total is not None
+            and steps_total > 0
+            and steps_completed is not None
+            and steps_completed >= steps_total
+        )
+
+    def _forward_tag_headers(self, forward_tag: str | None) -> dict | None:
+        """Build the header dict echoing the query forward tag.
+
+        Args:
+            forward_tag: Forward tag from the launch response (may be None).
+
+        Returns:
+            Dict with the forward tag header, or None when no tag exists.
+
+        """
+        if not forward_tag:
+            return None
+        return {FORWARD_TAG_HEADER: forward_tag}
+
+    def _extract_forward_tag(self, response: Any) -> str | None:
+        """Extract the query forward tag from launch response headers.
+
+        The header name is matched case-insensitively, per the SDL v2
+        contract (x-dataset-query-forward-tag).
+
+        Args:
+            response: Launch HTTP response.
+
+        Returns:
+            Forward tag value, or None if the header is absent.
+
+        """
+        headers = getattr(response, "headers", None)
+        if not isinstance(headers, dict):
+            return None
+        for key, value in headers.items():
+            if key.lower() == FORWARD_TAG_HEADER:
+                return value
+        return None
+
+    def _send_with_rate_limit_retry(
+        self, method: str, endpoint: str, **extra_kwargs: Any
+    ) -> Any:
+        """Send an SDL API request, retrying bounded times on HTTP 429.
+
+        The SDL v2 API rate limit is 8 requests with a 5/s refill, so a
+        429 is retried with a growing backoff up to MAX_RATE_LIMIT_RETRIES
+        times before failing.
+
+        Args:
+            method: Session method to call ("post" or "get").
+            endpoint: Full endpoint URL to request.
+            extra_kwargs: Keyword arguments forwarded to the session call.
+
+        Returns:
+            The first non-429 HTTP response.
+
+        Raises:
+            SentinelOneNetworkError: If a connection or timeout error occurs.
+            SentinelOneAPIError: If the request fails or the rate limit is
+                exhausted.
+
+        """
+        attempt = 0
+        while True:
+            try:
+                response = getattr(self.client_api.session, method)(
+                    endpoint, **extra_kwargs
+                )
+            except (ConnectionError, Timeout) as e:
+                raise SentinelOneNetworkError(
+                    f"Network error making SDL request ({method} {endpoint}): {e}"
+                ) from e
+            except RequestException as e:
+                raise SentinelOneAPIError(
+                    f"HTTP request failed for SDL request ({method} {endpoint}): {e}"
+                ) from e
+
+            if response.status_code != 429:
+                return response
+
+            attempt += 1
+            if attempt > MAX_RATE_LIMIT_RETRIES:
+                raise SentinelOneAPIError(
+                    f"SDL request rate limited (HTTP 429) after "
+                    f"{MAX_RATE_LIMIT_RETRIES} retries: {method} {endpoint}"
+                )
+
+            backoff = self._rate_limit_backoff_seconds(attempt)
+            self.logger.warning(
+                f"{LOG_PREFIX} SDL rate limited (HTTP 429); "
+                f"retry {attempt}/{MAX_RATE_LIMIT_RETRIES} in {backoff}s"
+            )
+            time.sleep(backoff)
+
+    def _rate_limit_backoff_seconds(self, attempt: int) -> int:
+        """Compute the backoff before the given 429 retry.
+
+        Args:
+            attempt: 1-based retry number.
+
+        Returns:
+            Backoff in seconds: 5, 10, 15, 15, capped at 15.
+
+        """
+        return min(5 * attempt, 15)
+
+    def _raise_for_error_response(self, response: Any, context: str) -> None:
+        """Raise SentinelOneAPIError for a non-200 SDL response.
+
+        Args:
+            response: HTTP response with a non-200 status.
+            context: Human-readable description of the operation.
+
+        Raises:
+            SentinelOneAPIError: Always, with the status and parsed details.
+
+        """
+        status = response.status_code
+        detail = self._parse_error_response(response)
+        if status == 404:
+            raise SentinelOneAPIError(f"{context} failed with status 404: {detail}")
+        raise SentinelOneAPIError(f"{context} failed with status {status}: {detail}")
+
+    def _parse_error_response(self, response: Any) -> str:
+        """Parse an SDL error body into a compact detail string.
+
+        Args:
+            response: HTTP error response.
+
+        Returns:
+            Detail string: "code=...; message=...; details=..." for SDL
+            error bodies, or the raw response text otherwise.
+
+        """
+        try:
+            if hasattr(response, "json"):
+                data = response.json()
+                if isinstance(data, dict) and ("code" in data or "message" in data):
+                    return self._format_sdl_error(data)
+            return getattr(response, "text", str(response))
+        except Exception as e:
+            return f"Error parsing response: {e}"
+
+    def _format_sdl_error(self, data: dict) -> str:
+        """Format an SDL v2 error body (code/message/details).
+
+        Args:
+            data: Parsed error body.
+
+        Returns:
+            Semicolon-joined "key=value" detail string.
+
+        """
+        parts = []
+        if data.get("code") is not None:
+            parts.append(f"code={data['code']}")
+        if data.get("message") is not None:
+            parts.append(f"message={data['message']}")
+        details = data.get("details")
+        if details:
+            if isinstance(details, list):
+                formatted = "; ".join(
+                    self._format_detail_item(item) for item in details
+                )
+                parts.append(f"details={formatted}")
+            else:
+                parts.append(f"details={details}")
+        return "; ".join(parts) if parts else str(data)
+
+    def _format_detail_item(self, item: Any) -> str:
+        """Format one SDL error detail entry.
+
+        Args:
+            item: Detail entry (dict with field/message, or any other value).
+
+        Returns:
+            "field: message" when structured, else the string form.
+
+        """
+        if isinstance(item, dict):
+            field = item.get("field")
+            message = item.get("message")
+            if field:
+                return f"{field}: {message}"
+            return str(message)
+        return str(item)
+
+    def _map_row_to_event(self, row: dict) -> dict[str, Any]:
+        """Map an SDL v2 match row to the Deep-Visibility-shaped event dict.
+
+        All fields are read with .get() so missing keys become None. The
+        fileSha1 key is the contract used by model_threat and by the
+        single-sha1 filtering.
+
+        Args:
+            row: Raw SDL match row.
+
+        Returns:
+            Event dictionary with the expected keys.
+
+        """
+        values = row.get("values")
+        if not isinstance(values, dict):
+            values = {}
+
+        return {
+            "fileSha1": values.get("tgt.file.sha1"),
+            "fileSha256": values.get("tgt.file.sha256"),
+            "fileId": values.get("tgt.file.id"),
+            "parentProcessName": values.get("src.process.parent.name"),
+            "processName": values.get("src.process.name"),
+            "processCmdline": values.get("src.process.cmdline"),
+            "parentProcessCmdline": values.get("src.process.parent.cmdline"),
+            "hostname": values.get("endpoint.name"),
+            "eventType": values.get("event.type"),
+            "eventTime": self._format_event_time(values.get("event.time")),
+            "eventId": values.get("event.id"),
+            "raw": values,
+        }
+
+    def _format_event_time(self, event_time: Any) -> str | None:
+        """Convert an event.time millisecond epoch to an ISO-8601 Z string.
+
+        Args:
+            event_time: Millisecond epoch (int, float, or numeric string).
+
+        Returns:
+            ISO-8601 UTC string ending in Z, or None when absent/invalid.
+
+        """
+        if event_time is None:
+            return None
+        if isinstance(event_time, str):
+            try:
+                event_time = float(event_time)
+            except ValueError:
+                return None
+        try:
+            dt = datetime.fromtimestamp(float(event_time) / 1000.0, tz=timezone.utc)
+        except (OverflowError, OSError, ValueError):
+            return None
+        return dt.isoformat().replace("+00:00", "Z")
+
+    def _format_timestamp(self, dt: datetime) -> str:
+        """Format a datetime for SDL v2 API timestamps.
+
+        SDL v2 expects ISO-8601 UTC with a Z suffix, e.g.
+        2026-08-31T00:00:00Z.
+
+        Args:
+            dt: Datetime to format (naive values are treated as UTC).
+
+        Returns:
+            ISO-8601 UTC string ending in Z.
+
+        """
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        elif dt.tzinfo != timezone.utc:
+            dt = dt.astimezone(timezone.utc)
+
+        return dt.replace(tzinfo=None).isoformat() + "Z"

--- a/sentinelone/src/services/fetcher_threat.py
+++ b/sentinelone/src/services/fetcher_threat.py
@@ -91,7 +91,7 @@ class FetcherThreat:
                 f"{LOG_PREFIX} Fetching threats for time window: {start_time_str} to {end_time_str}"
             )
 
-            response = self.client_api.session.get(endpoint, params=params)
+            response = self.client_api.session.get(endpoint, params=params, timeout=30)
             response.raise_for_status()
 
             json_data = response.json()

--- a/sentinelone/src/services/fetcher_threat_events.py
+++ b/sentinelone/src/services/fetcher_threat_events.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from .client_api import SentinelOneClientAPI
 
 LOG_PREFIX = "[SentinelOneThreatEventsFetcher]"
+MAX_PAGES = 200
 
 
 class FetcherThreatEvents:
@@ -108,17 +109,34 @@ class FetcherThreatEvents:
         """
         try:
             endpoint = f"{self.client_api.base_url}/web/api/v2.1/threats/{threat.threat_id}/explore/events"
-            params = {"limit": limit}
+            events: list[dict[str, Any]] = []
+            cursor: str | None = None
+            seen_cursors: set[str] = set()
 
-            self.logger.debug(
-                f"{LOG_PREFIX} Making API call to fetch events for threat {threat.threat_id}"
-            )
+            for _page_number in range(1, MAX_PAGES + 1):
+                params: dict[str, Any] = {"limit": limit}
+                if cursor is not None:
+                    params["cursor"] = cursor
 
-            response = self.client_api.session.get(endpoint, params=params)
-            response.raise_for_status()
+                self.logger.debug(
+                    f"{LOG_PREFIX} Making API call to fetch events for threat {threat.threat_id}"
+                )
 
-            json_data = response.json()
-            events = json_data.get("data", [])
+                response = self.client_api.session.get(
+                    endpoint, params=params, timeout=30
+                )
+                response.raise_for_status()
+
+                json_data = response.json()
+                events.extend(json_data.get("data", []))
+
+                pagination = json_data.get("pagination") or {}
+                next_cursor = pagination.get("nextCursor")
+                if not next_cursor or next_cursor in seen_cursors:
+                    break
+
+                seen_cursors.add(next_cursor)
+                cursor = next_cursor
 
             self.logger.debug(
                 f"{LOG_PREFIX} Retrieved {len(events)} events for threat {threat.threat_id}"

--- a/sentinelone/src/services/fetcher_unified_alerts.py
+++ b/sentinelone/src/services/fetcher_unified_alerts.py
@@ -1,0 +1,357 @@
+"""SentinelOne Unified Alerts fetcher (Singularity alerts GraphQL API).
+
+The legacy Threats API only surfaces convicted threats (static-engine
+reputation hits, mitigated behavioral threats). SentinelOne's newer
+behavioral / STAR / AI detections land in **Unified Alerts**, exposed by a
+separate GraphQL endpoint (``/web/api/v2.1/unifiedalerts/graphql``, Bearer
+auth) and never returned by ``/threats``. An OpenAEV inject such as
+"In-Memory Mimikatz-DumpCreds" typically raises a Unified Alert
+("Potential Mimikatz Execution") without ever producing a Threat, so a
+collector that reads only ``/threats`` reports Not Detected even though the
+SentinelOne console shows the detection.
+
+This fetcher lists Unified Alerts in the fetch window and maps each one to
+the existing Deep-Visibility-shaped ``SentinelOneThreat`` + event contract,
+so the unchanged matching pipeline can correlate them to expectations. The
+OpenAEV implant process name (the ``parent_process_name`` signature the
+matcher fuzzy-matches on) is recovered from the alert's OCSF ``rawData``.
+"""
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+from requests import ConnectionError, RequestException, Timeout
+
+from .client_api import SentinelOneClientAPI
+from .exception import (
+    SentinelOneAPIError,
+    SentinelOneNetworkError,
+    SentinelOneValidationError,
+)
+from .model_threat import SentinelOneThreat
+
+LOG_PREFIX = "[FetcherUnifiedAlerts]"
+REQUEST_TIMEOUT_SECONDS = 30
+PAGE_SIZE = 100
+MAX_PAGES = 50
+
+# The OpenAEV implant image name carries the inject id and the agent id, e.g.
+# oaev-implant-<inject-uuid>-agent-<agent-uuid>.exe. It is the exact value of
+# the expectation's parent_process_name signature, so recovering it from the
+# alert is what lets a behavioral alert correlate to an OpenAEV expectation.
+_IMPLANT_RE = re.compile(r"oaev-implant-[0-9a-fA-F-]+-agent-[0-9a-fA-F-]+(?:\.exe)?")
+
+_ALERTS_QUERY = """
+query($filters: [FilterInput!], $first: Int, $after: String) {
+  alerts(filters: $filters, first: $first, after: $after,
+         sort: {by: "detectedAt", order: DESC}) {
+    pageInfo { hasNextPage endCursor }
+    edges {
+      node {
+        id
+        name
+        detectedAt
+        status
+        result
+        storylineId
+        assets { name osType }
+        process { parentName cmdLine }
+      }
+    }
+  }
+}
+"""
+
+# rawData (the OCSF blob holding the full process ancestry, hence the OpenAEV
+# implant image name) lives on UnifiedAlertDetail, not on the list node, so it
+# is fetched per alert.
+_DETAIL_QUERY = """
+query($id: ID!) {
+  alert(id: $id) { rawData }
+}
+"""
+
+# Defensive cap on per-alert detail fetches in a single cycle.
+MAX_DETAIL_FETCHES = 200
+
+
+class FetcherUnifiedAlerts:
+    """Fetcher for SentinelOne Unified Alerts, mapped to the threat shape."""
+
+    def __init__(self, client_api: SentinelOneClientAPI):
+        """Initialize the Unified Alerts fetcher.
+
+        Args:
+            client_api: SentinelOne API client instance.
+
+        """
+        self.client_api = client_api
+        self.logger = logging.getLogger(__name__)
+
+    def fetch_alert_threats(
+        self, start_time: datetime, end_time: datetime
+    ) -> tuple[list[SentinelOneThreat], dict[str, list[dict[str, Any]]]]:
+        """Fetch Unified Alerts in the window as threats + synthetic events.
+
+        Args:
+            start_time: Window start (inclusive).
+            end_time: Window end (inclusive).
+
+        Returns:
+            Tuple of (threats, events_by_threat_id) where each threat is a
+            ``SentinelOneThreat`` derived from one alert and the events carry
+            the recovered OpenAEV implant name as ``parentProcessName`` so the
+            existing matcher can fuzzy-match the expectation.
+
+        Raises:
+            SentinelOneValidationError: If the window is invalid.
+            SentinelOneNetworkError: On a transport failure (transient).
+            SentinelOneAPIError: On an HTTP or GraphQL failure.
+
+        """
+        if not isinstance(start_time, datetime) or not isinstance(end_time, datetime):
+            raise SentinelOneValidationError(
+                "start_time and end_time must be datetime objects"
+            )
+        if start_time >= end_time:
+            raise SentinelOneValidationError("start_time must be before end_time")
+
+        filters = [
+            {
+                "fieldId": "detectedAt",
+                "dateTimeRange": {
+                    "start": self._to_epoch_ms(start_time),
+                    "end": self._to_epoch_ms(end_time),
+                    "startInclusive": True,
+                    "endInclusive": True,
+                },
+            }
+        ]
+
+        nodes = self._fetch_all_alert_nodes(filters)
+
+        threats: list[SentinelOneThreat] = []
+        events_by_id: dict[str, list[dict[str, Any]]] = {}
+        for index, node in enumerate(nodes):
+            if index < MAX_DETAIL_FETCHES:
+                node["rawData"] = self._fetch_raw_data(node.get("id"))
+            threat, events = self._map_alert_to_threat(node)
+            if threat is None:
+                continue
+            threats.append(threat)
+            if events:
+                events_by_id.setdefault(threat.threat_id, []).extend(events)
+
+        self.logger.info(
+            f"{LOG_PREFIX} Fetched {len(threats)} unified alerts for the window "
+            f"[{start_time.isoformat()} .. {end_time.isoformat()}]"
+        )
+        return threats, events_by_id
+
+    def _fetch_all_alert_nodes(self, filters: list[dict]) -> list[dict]:
+        """Page through the alerts connection and collect the raw nodes.
+
+        Args:
+            filters: GraphQL ``FilterInput`` list (already built).
+
+        Returns:
+            List of alert node dicts.
+
+        Raises:
+            SentinelOneNetworkError: On a transport failure.
+            SentinelOneAPIError: On an HTTP or GraphQL failure.
+
+        """
+        nodes: list[dict] = []
+        after: str | None = None
+
+        for _page in range(MAX_PAGES):
+            variables: dict[str, Any] = {"first": PAGE_SIZE, "filters": filters}
+            if after is not None:
+                variables["after"] = after
+
+            body = self._post_graphql(_ALERTS_QUERY, variables)
+            connection = (body.get("data") or {}).get("alerts") or {}
+            for edge in connection.get("edges") or []:
+                node = edge.get("node")
+                if isinstance(node, dict):
+                    nodes.append(node)
+
+            page_info = connection.get("pageInfo") or {}
+            if not page_info.get("hasNextPage"):
+                break
+            after = page_info.get("endCursor")
+            if not after:
+                break
+        else:
+            self.logger.warning(
+                f"{LOG_PREFIX} Reached the maximum of {MAX_PAGES} alert pages; "
+                f"returning {len(nodes)} nodes"
+            )
+
+        return nodes
+
+    def _fetch_raw_data(self, alert_id: Any) -> Any:
+        """Fetch one alert's OCSF ``rawData`` (holds the process ancestry).
+
+        Args:
+            alert_id: The alert id.
+
+        Returns:
+            The ``rawData`` value (dict or str), or None when unavailable.
+
+        Raises:
+            SentinelOneNetworkError: On a transport failure.
+            SentinelOneAPIError: On an HTTP or GraphQL failure.
+
+        """
+        if not alert_id:
+            return None
+        body = self._post_graphql(_DETAIL_QUERY, {"id": str(alert_id)})
+        return ((body.get("data") or {}).get("alert") or {}).get("rawData")
+
+    def _post_graphql(self, query: str, variables: dict) -> dict:
+        """POST a GraphQL request with Bearer auth and typed error handling.
+
+        Args:
+            query: GraphQL query string.
+            variables: GraphQL variables.
+
+        Returns:
+            The parsed JSON response body.
+
+        Raises:
+            SentinelOneNetworkError: On a connection or timeout error.
+            SentinelOneAPIError: On an HTTP error or a GraphQL ``errors`` block.
+
+        """
+        endpoint = f"{self.client_api.base_url}/web/api/v2.1/unifiedalerts/graphql"
+        headers = {"Authorization": f"Bearer {self.client_api.api_key}"}
+
+        try:
+            response = self.client_api.session.post(
+                endpoint,
+                json={"query": query, "variables": variables},
+                headers=headers,
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+        except (ConnectionError, Timeout) as e:
+            raise SentinelOneNetworkError(
+                f"Network error querying Unified Alerts: {e}"
+            ) from e
+        except RequestException as e:
+            raise SentinelOneAPIError(
+                f"HTTP request failed querying Unified Alerts: {e}"
+            ) from e
+
+        if response.status_code != 200:
+            raise SentinelOneAPIError(
+                f"Unified Alerts query failed with status "
+                f"{response.status_code}: {response.text[:200]}"
+            )
+
+        body = response.json()
+        if isinstance(body, dict) and body.get("errors"):
+            raise SentinelOneAPIError(
+                f"Unified Alerts GraphQL error: {json.dumps(body['errors'])[:300]}"
+            )
+        return body if isinstance(body, dict) else {}
+
+    def _map_alert_to_threat(
+        self, node: dict
+    ) -> tuple[SentinelOneThreat | None, list[dict[str, Any]]]:
+        """Map one alert node to a ``SentinelOneThreat`` + implant events.
+
+        Args:
+            node: Alert node dict from the GraphQL response.
+
+        Returns:
+            Tuple of (threat or None, events). ``None`` when the alert has no
+            id. Events carry the recovered implant name as
+            ``parentProcessName`` (empty when none could be recovered, in
+            which case a parent_process_name expectation will simply not
+            match, avoiding a false positive).
+
+        """
+        alert_id = node.get("id")
+        if not alert_id:
+            return None, []
+
+        assets = node.get("assets") or []
+        hostname = (
+            assets[0].get("name") if assets and isinstance(assets[0], dict) else None
+        )
+
+        # Prevention polarity: MITIGATED means SentinelOne actively blocked the
+        # activity; BENIGN / UNMITIGATED / absent means detect-only.
+        is_mitigated = node.get("result") == "MITIGATED"
+
+        threat = SentinelOneThreat(
+            threat_id=str(alert_id),
+            hostname=hostname,
+            is_mitigated=is_mitigated,
+            is_static=False,
+            sha1=None,
+        )
+        threat._raw = node
+
+        implants = self._extract_implant_names(node)
+        events = [
+            {
+                "parentProcessName": implant,
+                "processName": None,
+                "hostname": hostname,
+                "eventType": "unified_alert",
+                "eventTime": node.get("detectedAt"),
+                "fileSha1": None,
+            }
+            for implant in implants
+        ]
+        return threat, events
+
+    def _extract_implant_names(self, node: dict) -> list[str]:
+        """Recover the OpenAEV implant process name(s) from an alert node.
+
+        The implant is the parent of the payload process. It is searched for
+        in the process fields and, as the reliable source, in the OCSF
+        ``rawData`` blob (the console keeps the full process ancestry there).
+
+        Args:
+            node: Alert node dict.
+
+        Returns:
+            Sorted unique list of implant image names found on the alert.
+
+        """
+        haystacks: list[str] = []
+        process = node.get("process")
+        if isinstance(process, dict):
+            for key in ("parentName", "cmdLine"):
+                value = process.get(key)
+                if isinstance(value, str):
+                    haystacks.append(value)
+        raw = node.get("rawData")
+        if raw is not None:
+            haystacks.append(raw if isinstance(raw, str) else json.dumps(raw))
+
+        found: set[str] = set()
+        for text in haystacks:
+            found.update(_IMPLANT_RE.findall(text))
+        return sorted(found)
+
+    def _to_epoch_ms(self, dt: datetime) -> int:
+        """Convert a datetime to an epoch-millisecond integer (UTC).
+
+        Args:
+            dt: Datetime to convert (naive values are treated as UTC).
+
+        Returns:
+            Milliseconds since the Unix epoch.
+
+        """
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp() * 1000)

--- a/sentinelone/src/services/utils/signature_extractor.py
+++ b/sentinelone/src/services/utils/signature_extractor.py
@@ -86,6 +86,36 @@ class SignatureExtractor:
         return None
 
     @staticmethod
+    def extract_start_date(
+        batch: list["DetectionExpectation | PreventionExpectation"] | None = None,
+    ) -> datetime | None:
+        """Extract start_date from batch signatures.
+
+        Args:
+            batch: List of expectations to extract start_date from. If None, returns None.
+
+        Returns:
+            Parsed start_date as datetime or None if no valid start_date signature found.
+
+        """
+        if not batch:
+            return None
+
+        for expectation in batch:
+            for signature in expectation.inject_expectation_signatures:
+                if signature.type.value == "start_date":
+                    try:
+                        start_date = datetime.fromisoformat(
+                            signature.value.replace("Z", "+00:00")
+                        )
+                        if start_date.tzinfo is None:
+                            start_date = start_date.replace(tzinfo=timezone.utc)
+                        return start_date
+                    except (ValueError, AttributeError):
+                        continue
+        return None
+
+    @staticmethod
     def group_signatures_by_type(
         expectation: "DetectionExpectation | PreventionExpectation",
         supported_signatures: list[SignatureTypes] | None = None,

--- a/sentinelone/src/services/utils/signature_extractor.py
+++ b/sentinelone/src/services/utils/signature_extractor.py
@@ -101,6 +101,7 @@ class SignatureExtractor:
         if not batch:
             return None
 
+        earliest: datetime | None = None
         for expectation in batch:
             for signature in expectation.inject_expectation_signatures:
                 if signature.type.value == "start_date":
@@ -110,10 +111,11 @@ class SignatureExtractor:
                         )
                         if start_date.tzinfo is None:
                             start_date = start_date.replace(tzinfo=timezone.utc)
-                        return start_date
+                        if earliest is None or start_date < earliest:
+                            earliest = start_date
                     except (ValueError, AttributeError):
                         continue
-        return None
+        return earliest
 
     @staticmethod
     def group_signatures_by_type(

--- a/sentinelone/tests/services/test_expectation_service.py
+++ b/sentinelone/tests/services/test_expectation_service.py
@@ -1,7 +1,7 @@
 """Essential tests for SentinelOne Expectation Service - Gherkin GWT Format."""
 
-from datetime import datetime
-from unittest.mock import ANY, Mock
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
 from uuid import uuid4
 
 import pytest
@@ -188,9 +188,11 @@ def test_match_threats_to_expectations():
     _then_match_succeeds_without_mitigation_requirement(matches)
 
 
-# Scenario: Fetch windows honor the signature start date
-def test_fetch_windows_use_signature_start_date():
-    """Scenario: Fetch windows use the signature start date when present."""
+# Scenario: The alert window and the DV event window are decoupled
+def test_alert_and_dv_windows_are_decoupled():
+    """Scenario: The DV event window ignores the signature dates and pivots on
+    the file SHA1 with a fixed lookback, while the alert window keeps anchoring
+    its start to the signature start date."""
     # Given: A detection helper
     detection_helper = _given_mock_detection_helper()
     # Given: A static expectation with start and end date signatures
@@ -198,9 +200,12 @@ def test_fetch_windows_use_signature_start_date():
         start_date="2024-01-01T10:00:00Z",
         end_date="2024-01-01T12:00:00Z",
     )
+    # Given: A pinned DV lookback so the assertion is deterministic
+    lookback = timedelta(hours=6)
 
     # When: I handle the static expectation with Deep Visibility enabled
     with _given_expectation_service_with_deep_visibility_enabled() as service:
+        service.client_api.deep_visibility_lookback = lookback
         mock_static_threats = _given_mock_static_threats_for_service(service)
         mock_dv_events = _given_mock_deep_visibility_events_for_service(service)
 
@@ -209,15 +214,18 @@ def test_fetch_windows_use_signature_start_date():
                 service, [static_expectation], detection_helper
             )
 
-    # Then: Both the threat and DV windows use the signature start and end dates
-    _then_fetch_windows_use_signature_dates(
-        threats_mock, dv_mock, "2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z"
+    # Then: The alert window still uses the signature start date, and the DV
+    # event window spans exactly the pinned lookback ending at now
+    _then_alert_and_dv_windows_are_decoupled(
+        threats_mock, dv_mock, "2024-01-01T10:00:00Z", lookback
     )
 
 
-# Scenario: Fetch windows fall back to time window without a start date
+# Scenario: Fetch windows fall back to the time window without a start date
 def test_fetch_windows_fall_back_to_time_window_without_start_date():
-    """Scenario: Fetch windows fall back to time window without a start date."""
+    """Scenario: without a start date signature, the threat window spans
+    now - SENTINELONE_TIME_WINDOW to now.
+    """
     # Given: An initialized expectation service
     service = _given_initialized_expectation_service()
     # Given: An expectation without a start date signature
@@ -228,34 +236,34 @@ def test_fetch_windows_fall_back_to_time_window_without_start_date():
     # When: I compute the fetch time window for the batch
     start_time, end_time = _when_compute_fetch_time_window(service, [expectation])
 
-    # Then: The window spans end - SENTINELONE_TIME_WINDOW to end
-    _then_fetch_window_falls_back_to_time_window(
-        service, start_time, end_time, "2024-01-01T12:00:00Z"
-    )
+    # Then: The window spans now - SENTINELONE_TIME_WINDOW to now
+    _then_fetch_window_falls_back_to_time_window(service, start_time, end_time)
 
 
-# Scenario: Fetch windows fall back to time window when start date is after end
-def test_fetch_windows_fall_back_to_time_window_when_start_after_end():
-    """Scenario: Fetch windows fall back to time window when start date is after end."""
+# Scenario: Fetch windows fall back to the time window when the start date is in the future
+def test_fetch_windows_fall_back_to_time_window_when_start_in_future():
+    """Scenario: a start date after the current time is anomalous; the
+    threat window falls back to now - SENTINELONE_TIME_WINDOW to now.
+    """
     # Given: An initialized expectation service
     service = _given_initialized_expectation_service()
-    # Given: An expectation whose start date is after its end date
+    # Given: An expectation whose start date lies in the future
     expectation = _given_expectation_with_date_signatures(
-        start_date="2024-01-02T12:00:00Z", end_date="2024-01-01T12:00:00Z"
+        start_date="2999-01-01T12:00:00Z", end_date="2024-01-01T12:00:00Z"
     )
 
     # When: I compute the fetch time window for the batch
     start_time, end_time = _when_compute_fetch_time_window(service, [expectation])
 
-    # Then: The window spans end - SENTINELONE_TIME_WINDOW to end
-    _then_fetch_window_falls_back_to_time_window(
-        service, start_time, end_time, "2024-01-01T12:00:00Z"
-    )
+    # Then: The window spans now - SENTINELONE_TIME_WINDOW to now
+    _then_fetch_window_falls_back_to_time_window(service, start_time, end_time)
 
 
-# Scenario: Fetch windows fall back to time window when start date is unparsable
+# Scenario: Fetch windows fall back to the time window when the start date is unparsable
 def test_fetch_windows_fall_back_to_time_window_when_start_unparsable():
-    """Scenario: Fetch windows fall back to time window when start date is unparsable."""
+    """Scenario: an unparsable start date signature falls back to
+    now - SENTINELONE_TIME_WINDOW to now.
+    """
     # Given: An initialized expectation service
     service = _given_initialized_expectation_service()
     # Given: An expectation with an unparsable start date signature
@@ -266,10 +274,8 @@ def test_fetch_windows_fall_back_to_time_window_when_start_unparsable():
     # When: I compute the fetch time window for the batch
     start_time, end_time = _when_compute_fetch_time_window(service, [expectation])
 
-    # Then: The window spans end - SENTINELONE_TIME_WINDOW to end
-    _then_fetch_window_falls_back_to_time_window(
-        service, start_time, end_time, "2024-01-01T12:00:00Z"
-    )
+    # Then: The window spans now - SENTINELONE_TIME_WINDOW to now
+    _then_fetch_window_falls_back_to_time_window(service, start_time, end_time)
 
 
 # --------
@@ -884,43 +890,57 @@ def _then_static_result_without_deep_visibility_returned(result, expectation):
 
 
 # Then: Both the threat and DV windows use the signature start and end dates
-def _then_fetch_windows_use_signature_dates(
-    threats_mock, dv_mock, start_date, end_date
+def _then_alert_and_dv_windows_are_decoupled(
+    threats_mock, dv_mock, start_date, lookback
 ):
-    """Verify both fetchers received the signature-derived time window.
+    """Verify the alert window and the DV event window are decoupled.
+
+    The alert (threat) window keeps anchoring its start to the signature
+    start_date. The DV event window ignores the signature dates entirely: it
+    starts at now - lookback and ends at now, so it can reach a file that was
+    dropped or executed well before the alert that references it.
 
     Args:
         threats_mock: Mock of the threat fetcher time window fetch.
         dv_mock: Mock of the Deep Visibility batch SHA1 fetch.
         start_date: ISO 8601 start date signature value.
-        end_date: ISO 8601 end date signature value.
+        lookback: Pinned DV lookback duration.
 
     """
-    expected_start = _parse_date_signature(start_date)
-    expected_end = _parse_date_signature(end_date)
+    # Alert window: its start still anchors to the signature start_date.
+    assert threats_mock.call_args.kwargs["start_time"] == _parse_date_signature(
+        start_date
+    )  # noqa: S101
 
-    threats_mock.assert_called_once_with(
-        start_time=expected_start, end_time=expected_end, limit=1000
-    )
-    dv_mock.assert_called_once_with(ANY, expected_start, expected_end)
+    # DV window: spans exactly the pinned lookback and ends at now.
+    dv_start = dv_mock.call_args.args[1]
+    dv_end = dv_mock.call_args.args[2]
+    assert dv_end - dv_start == lookback  # noqa: S101
+
+    # The DV window is decoupled from the signature start date...
+    assert dv_start != _parse_date_signature(start_date)  # noqa: S101
+    # ...and both windows are now-anchored on the end.
+    assert abs(threats_mock.call_args.kwargs["end_time"] - dv_end) < timedelta(
+        minutes=1
+    )  # noqa: S101
 
 
-# Then: The window spans end - SENTINELONE_TIME_WINDOW to end
-def _then_fetch_window_falls_back_to_time_window(
-    service, start_time, end_time, end_date
-):
-    """Verify the fetch window fell back to end - SENTINELONE_TIME_WINDOW.
+# Then: The fallback window spans now - SENTINELONE_TIME_WINDOW to now
+def _then_fetch_window_falls_back_to_time_window(service, start_time, end_time):
+    """Verify the threat window fell back to now - SENTINELONE_TIME_WINDOW.
+
+    Under the decoupled contract the threat window ends at the current time;
+    the signature end date no longer anchors it.
 
     Args:
         service: The expectation service instance.
         start_time: Computed window start.
         end_time: Computed window end.
-        end_date: ISO 8601 end date signature value.
 
     """
-    expected_end = _parse_date_signature(end_date)
-    assert start_time == expected_end - service.client_api.time_window  # noqa: S101
-    assert end_time == expected_end  # noqa: S101
+    assert start_time == end_time - service.client_api.time_window  # noqa: S101
+    now_at_assertion = datetime.now(timezone.utc)
+    assert abs(end_time - now_at_assertion) < timedelta(minutes=1)  # noqa: S101
 
 
 # --------

--- a/sentinelone/tests/services/test_expectation_service.py
+++ b/sentinelone/tests/services/test_expectation_service.py
@@ -1,6 +1,7 @@
 """Essential tests for SentinelOne Expectation Service - Gherkin GWT Format."""
 
-from unittest.mock import Mock
+from datetime import datetime
+from unittest.mock import ANY, Mock
 from uuid import uuid4
 
 import pytest
@@ -185,6 +186,90 @@ def test_match_threats_to_expectations():
     _then_proper_matches_found(matches, threats, expectations)
     # Then: The match should succeed without requiring mitigation
     _then_match_succeeds_without_mitigation_requirement(matches)
+
+
+# Scenario: Fetch windows honor the signature start date
+def test_fetch_windows_use_signature_start_date():
+    """Scenario: Fetch windows use the signature start date when present."""
+    # Given: A detection helper
+    detection_helper = _given_mock_detection_helper()
+    # Given: A static expectation with start and end date signatures
+    static_expectation = _given_expectation_with_date_signatures(
+        start_date="2024-01-01T10:00:00Z",
+        end_date="2024-01-01T12:00:00Z",
+    )
+
+    # When: I handle the static expectation with Deep Visibility enabled
+    with _given_expectation_service_with_deep_visibility_enabled() as service:
+        mock_static_threats = _given_mock_static_threats_for_service(service)
+        mock_dv_events = _given_mock_deep_visibility_events_for_service(service)
+
+        with mock_static_threats as threats_mock, mock_dv_events as dv_mock:
+            _when_handle_batch_expectations(
+                service, [static_expectation], detection_helper
+            )
+
+    # Then: Both the threat and DV windows use the signature start and end dates
+    _then_fetch_windows_use_signature_dates(
+        threats_mock, dv_mock, "2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z"
+    )
+
+
+# Scenario: Fetch windows fall back to time window without a start date
+def test_fetch_windows_fall_back_to_time_window_without_start_date():
+    """Scenario: Fetch windows fall back to time window without a start date."""
+    # Given: An initialized expectation service
+    service = _given_initialized_expectation_service()
+    # Given: An expectation without a start date signature
+    expectation = _given_expectation_with_date_signatures(
+        start_date=None, end_date="2024-01-01T12:00:00Z"
+    )
+
+    # When: I compute the fetch time window for the batch
+    start_time, end_time = _when_compute_fetch_time_window(service, [expectation])
+
+    # Then: The window spans end - SENTINELONE_TIME_WINDOW to end
+    _then_fetch_window_falls_back_to_time_window(
+        service, start_time, end_time, "2024-01-01T12:00:00Z"
+    )
+
+
+# Scenario: Fetch windows fall back to time window when start date is after end
+def test_fetch_windows_fall_back_to_time_window_when_start_after_end():
+    """Scenario: Fetch windows fall back to time window when start date is after end."""
+    # Given: An initialized expectation service
+    service = _given_initialized_expectation_service()
+    # Given: An expectation whose start date is after its end date
+    expectation = _given_expectation_with_date_signatures(
+        start_date="2024-01-02T12:00:00Z", end_date="2024-01-01T12:00:00Z"
+    )
+
+    # When: I compute the fetch time window for the batch
+    start_time, end_time = _when_compute_fetch_time_window(service, [expectation])
+
+    # Then: The window spans end - SENTINELONE_TIME_WINDOW to end
+    _then_fetch_window_falls_back_to_time_window(
+        service, start_time, end_time, "2024-01-01T12:00:00Z"
+    )
+
+
+# Scenario: Fetch windows fall back to time window when start date is unparsable
+def test_fetch_windows_fall_back_to_time_window_when_start_unparsable():
+    """Scenario: Fetch windows fall back to time window when start date is unparsable."""
+    # Given: An initialized expectation service
+    service = _given_initialized_expectation_service()
+    # Given: An expectation with an unparsable start date signature
+    expectation = _given_expectation_with_date_signatures(
+        start_date="not-a-date", end_date="2024-01-01T12:00:00Z"
+    )
+
+    # When: I compute the fetch time window for the batch
+    start_time, end_time = _when_compute_fetch_time_window(service, [expectation])
+
+    # Then: The window spans end - SENTINELONE_TIME_WINDOW to end
+    _then_fetch_window_falls_back_to_time_window(
+        service, start_time, end_time, "2024-01-01T12:00:00Z"
+    )
 
 
 # --------
@@ -426,6 +511,37 @@ def _given_static_expectation():
     return expectation
 
 
+# Given: An expectation with date signatures
+def _given_expectation_with_date_signatures(start_date: str | None, end_date: str):
+    """Create a static expectation with date signatures.
+
+    Args:
+        start_date: ISO 8601 start date signature value, or None to omit.
+        end_date: ISO 8601 end date signature value.
+
+    Returns:
+        Mock static expectation.
+
+    """
+    signatures = [
+        _create_mock_signature(
+            SignatureTypes.SIG_TYPE_TARGET_HOSTNAME_ADDRESS,
+            "static-host.example.com",
+        )
+    ]
+    if start_date is not None:
+        signatures.append(
+            _create_mock_signature(SignatureTypes.SIG_TYPE_START_DATE, start_date)
+        )
+    signatures.append(
+        _create_mock_signature(SignatureTypes.SIG_TYPE_END_DATE, end_date)
+    )
+
+    return _create_mock_expectation(
+        expectation_id="static_date_test_1", signatures=signatures
+    )
+
+
 # Given: Mock static threats for service
 def _given_mock_static_threats_for_service(service):
     """Set up mock static threats for the service.
@@ -651,6 +767,21 @@ def _when_check_expectation_matches_threat(service, expectation, threat):
     )
 
 
+# When: I compute the fetch time window for a batch
+def _when_compute_fetch_time_window(service, batch):
+    """Compute the fetch time window for a batch.
+
+    Args:
+        service: The expectation service instance.
+        batch: Batch of expectations.
+
+    Returns:
+        Tuple of (start_time, end_time).
+
+    """
+    return service._get_fetch_time_window(batch)
+
+
 # --------
 # Then Methods
 # --------
@@ -752,6 +883,46 @@ def _then_static_result_without_deep_visibility_returned(result, expectation):
     assert result[0].is_valid  # noqa: S101
 
 
+# Then: Both the threat and DV windows use the signature start and end dates
+def _then_fetch_windows_use_signature_dates(
+    threats_mock, dv_mock, start_date, end_date
+):
+    """Verify both fetchers received the signature-derived time window.
+
+    Args:
+        threats_mock: Mock of the threat fetcher time window fetch.
+        dv_mock: Mock of the Deep Visibility batch SHA1 fetch.
+        start_date: ISO 8601 start date signature value.
+        end_date: ISO 8601 end date signature value.
+
+    """
+    expected_start = _parse_date_signature(start_date)
+    expected_end = _parse_date_signature(end_date)
+
+    threats_mock.assert_called_once_with(
+        start_time=expected_start, end_time=expected_end, limit=1000
+    )
+    dv_mock.assert_called_once_with(ANY, expected_start, expected_end)
+
+
+# Then: The window spans end - SENTINELONE_TIME_WINDOW to end
+def _then_fetch_window_falls_back_to_time_window(
+    service, start_time, end_time, end_date
+):
+    """Verify the fetch window fell back to end - SENTINELONE_TIME_WINDOW.
+
+    Args:
+        service: The expectation service instance.
+        start_time: Computed window start.
+        end_time: Computed window end.
+        end_date: ISO 8601 end date signature value.
+
+    """
+    expected_end = _parse_date_signature(end_date)
+    assert start_time == expected_end - service.client_api.time_window  # noqa: S101
+    assert end_time == expected_end  # noqa: S101
+
+
 # --------
 # Helper Methods
 # --------
@@ -795,3 +966,16 @@ def _create_mock_expectation(expectation_id=None, signatures=None):
     expectation.inject_expectation_signatures = signatures
     expectation.id = expectation_id
     return expectation
+
+
+def _parse_date_signature(value: str) -> datetime:
+    """Parse an ISO 8601 date signature value.
+
+    Args:
+        value: ISO 8601 date string, e.g. "2024-01-01T12:00:00Z".
+
+    Returns:
+        Parsed datetime.
+
+    """
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/sentinelone/tests/services/test_fetcher_sdl.py
+++ b/sentinelone/tests/services/test_fetcher_sdl.py
@@ -1,0 +1,775 @@
+"""Essential tests for the SentinelOne SDL v2 deep-search fetcher - Gherkin GWT Format."""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from src.services.exception import (
+    SentinelOneAPIError,
+    SentinelOneNetworkError,
+    SentinelOneValidationError,
+)
+from src.services.expectation_service import SentinelOneExpectationService
+from src.services.fetcher_deep_visibility import FetcherDeepVisibility
+from src.services.fetcher_sdl import FetcherSDL
+from tests.services.fixtures.factories import create_test_config
+
+# --------
+# Fixtures
+# --------
+
+
+@pytest.fixture(autouse=True)
+def mock_logging() -> logging.Logger:
+    """Shadow the services conftest ``mock_logging`` fixture for this module.
+
+    The conftest autouse fixture replaces every named logger with a shared
+    ``Mock``; log calls on that mock never reach the real logging hierarchy,
+    so the ``caplog`` fixture cannot observe them. The 429 retry scenario
+    must emit its warning through the real loggers for ``caplog`` to
+    capture it, so this module-level fixture shadows the conftest one and
+    restores real logging for this module only.
+
+    Yields:
+        The real root logger.
+
+    """
+    yield logging.getLogger()
+
+
+# --------
+# Given Helpers
+# --------
+
+
+def _given_mock_client_api(is_self_hosted: bool) -> Mock:
+    """Create a mock client API exposing the SDL fetcher's contract surface.
+
+    Args:
+        is_self_hosted: Value of the client's is_self_hosted flag.
+
+    Returns:
+        Mock client API with base_url, time_window, and session set.
+
+    """
+    client = Mock()
+    client.base_url = "https://s1.example.com"
+    client.time_window = timedelta(hours=1)
+    client.is_self_hosted = is_self_hosted
+    return client
+
+
+def _given_sdl_fetcher(is_self_hosted: bool = False) -> tuple[FetcherSDL, Mock]:
+    """Create an SDL fetcher wired to a fresh mock session.
+
+    Args:
+        is_self_hosted: Value of the client's is_self_hosted flag.
+
+    Returns:
+        Tuple of (FetcherSDL instance, mock session).
+
+    """
+    session = Mock()
+    client = _given_mock_client_api(is_self_hosted)
+    client.session = session
+    return FetcherSDL(client), session
+
+
+def _given_valid_sha1() -> str:
+    """Create a valid SHA1 hash for tests.
+
+    Returns:
+        Valid SHA1 string.
+
+    """
+    return "a1b2c3d4e5f6789012345678901234567890abcd"
+
+
+def _given_valid_sha1_list() -> list[str]:
+    """Create a list of valid SHA1 hashes for tests.
+
+    Returns:
+        List of three valid SHA1 strings.
+
+    """
+    return [
+        "a1b2c3d4e5f6789012345678901234567890abcd",
+        "b2c3d4e5f6789012345678901234567890abcdef",
+        "c3d4e5f6789012345678901234567890abcdef01",
+    ]
+
+
+def _given_valid_time_range() -> tuple[datetime, datetime]:
+    """Create a fixed UTC time range for tests.
+
+    Returns:
+        Tuple of (start, end) tz-aware datetimes.
+
+    """
+    start = datetime(2026, 8, 1, 0, 0, 0, tzinfo=timezone.utc)
+    end = datetime(2026, 8, 31, 23, 59, 59, tzinfo=timezone.utc)
+    return start, end
+
+
+def _given_row(
+    cursor: str,
+    sha1: str,
+    event_id: str,
+    parent_name: str,
+    process_name: str,
+    event_type: str,
+    event_time_ms: int,
+    hostname: str = "kingslanding",
+) -> dict[str, Any]:
+    """Create one SDL v2 match row in the verified row shape.
+
+    Args:
+        cursor: Row cursor (G/... in production).
+        sha1: tgt.file.sha1 value.
+        event_id: event.id value.
+        parent_name: src.process.parent.name value.
+        process_name: src.process.name value.
+        event_type: event.type value.
+        event_time_ms: event.time in milliseconds.
+        hostname: endpoint.name value.
+
+    Returns:
+        Raw SDL match row dictionary.
+
+    """
+    return {
+        "cursor": cursor,
+        "serverInfo": {},
+        "sessionId": "",
+        "severity": 3,
+        "threadId": "",
+        "timestamp": event_time_ms * 1_000_000,
+        "values": {
+            "tgt.file.sha1": sha1,
+            "tgt.file.sha256": "f" * 64,
+            "tgt.file.id": "7F8BC31AF4A291CB",
+            "tgt.file.name": "implant.exe",
+            "tgt.file.path": "C:\\ProgramData\\implant.exe",
+            "src.process.name": process_name,
+            "src.process.cmdline": f"C:\\Windows\\System32\\{process_name}",
+            "src.process.image.path": "C:\\Windows\\System32\\",
+            "src.process.parent.name": parent_name,
+            "src.process.parent.cmdline": "C:\\Windows\\explorer.exe",
+            "src.process.parent.image.path": "C:\\Windows\\",
+            "endpoint.name": hostname,
+            "event.type": event_type,
+            "event.time": event_time_ms,
+            "event.id": event_id,
+            "account.name": "svc-alerts",
+        },
+    }
+
+
+def _given_launch_response(query_id: str, forward_tag: str = "G/fwd-tag-1") -> Mock:
+    """Create a 200 SDL query-launch response.
+
+    The forward tag header is deliberately mixed-case: the fetcher must
+    match it case-insensitively and echo it back in canonical case.
+
+    Args:
+        query_id: Query id to return in the body.
+        forward_tag: Forward tag header value.
+
+    Returns:
+        Mock response with status, headers, and json body.
+
+    """
+    response = Mock()
+    response.status_code = 200
+    response.headers = {"X-Dataset-Query-Forward-Tag": forward_tag}
+    response.json.return_value = {
+        "id": query_id,
+        "stepsCompleted": 2,
+        "stepsTotal": 2,
+        "totalSteps": 2,
+        "data": {"estimatedMatchCount": 0.0, "matches": []},
+    }
+    return response
+
+
+def _given_poll_response(
+    query_id: str,
+    rows: list[dict[str, Any]],
+    estimated_match_count: float,
+    steps_completed: int,
+    steps_total: int = 2,
+) -> Mock:
+    """Create a 200 SDL query-poll response.
+
+    Args:
+        query_id: Query id echoed in the body.
+        rows: Match rows in the data block.
+        estimated_match_count: estimatedMatchCount in the data block.
+        steps_completed: stepsCompleted value.
+        steps_total: stepsTotal value.
+
+    Returns:
+        Mock response with status and json body.
+
+    """
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "id": query_id,
+        "stepsCompleted": steps_completed,
+        "stepsTotal": steps_total,
+        "totalSteps": steps_total,
+        "data": {
+            "estimatedMatchCount": estimated_match_count,
+            "matches": rows,
+        },
+    }
+    return response
+
+
+def _given_mock_session_get(account_type_present: bool) -> Mock:
+    """Create a replacement for requests.Session.get with an account listing.
+
+    Args:
+        account_type_present: Whether one account exposes an accountType
+            field (SaaS) or none do (self-hosted).
+
+    Returns:
+        Mock callable returning the listing response.
+
+    """
+    if account_type_present:
+        accounts = [{"id": "acc-1", "name": "SaaS Tenant", "accountType": "Trial"}]
+    else:
+        accounts = [{"id": "acc-1", "name": "Legacy Tenant"}]
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = {"data": accounts}
+    return Mock(return_value=response)
+
+
+# --------
+# Scenarios
+# --------
+
+
+# Scenario: A single SHA1 filter uses only verified S1QL 2.0 fields
+def test_single_sha1_filter_uses_verified_s1ql_2_fields():
+    """Scenario: A single SHA1 filter uses only verified S1QL 2.0 fields."""
+    # Given: An SDL fetcher
+    fetcher, _ = _given_sdl_fetcher()
+    # Given: A valid SHA1
+    sha1 = _given_valid_sha1()
+
+    # When: The S1QL filter is built for the single SHA1
+    filter_expr = fetcher._build_s1ql_filter([sha1])
+
+    # Then: The filter is tenant-wide and uses verified 2.0 field names only
+    base = "dataSource.name='SentinelOne' dataSource.category='security'"
+    assert filter_expr == f"{base} tgt.file.sha1='{sha1}'"  # noqa: S101
+    assert "endpoint.name" not in filter_expr  # noqa: S101
+    assert "agent.hostname" not in filter_expr  # noqa: S101
+
+
+# Scenario: A batch filter OR-joins every SHA1 without a host filter
+def test_batch_sha1_filter_or_joins_all_sha1s():
+    """Scenario: A batch filter OR-joins every SHA1 without a host filter."""
+    # Given: An SDL fetcher
+    fetcher, _ = _given_sdl_fetcher()
+    # Given: A list of valid SHA1s
+    sha1s = _given_valid_sha1_list()
+
+    # When: The S1QL filter is built for the batch
+    filter_expr = fetcher._build_s1ql_filter(sha1s)
+
+    # Then: Every SHA1 is OR-joined inside the tenant-wide base clauses
+    base = "dataSource.name='SentinelOne' dataSource.category='security'"
+    or_expr = " or ".join(f"tgt.file.sha1='{s}'" for s in sha1s)
+    assert filter_expr == f"{base} ({or_expr})"  # noqa: S101
+    assert "endpoint.name" not in filter_expr  # noqa: S101
+
+
+# Scenario: S1QL string values are defensively escaped
+def test_s1ql_string_values_are_escaped():
+    """Scenario: S1QL string values are defensively escaped."""
+    # Given: An SDL fetcher
+    fetcher, _ = _given_sdl_fetcher()
+
+    # When: A value containing a quote and a backslash is escaped
+    escaped = fetcher._escape_s1ql_string("a'b\\c")
+
+    # Then: Backslashes are escaped before quotes
+    assert escaped == "a\\'b\\\\c"  # noqa: S101
+
+
+# Scenario: The launch body matches the verified SDL v2 contract
+def test_launch_body_matches_sdl_v2_contract():
+    """Scenario: The launch body matches the verified SDL v2 contract."""
+    # Given: An SDL fetcher
+    fetcher, _ = _given_sdl_fetcher()
+    # Given: A valid time range
+    start, end = _given_valid_time_range()
+
+    # When: A first-page launch body is built (no cursor)
+    body = fetcher._build_launch_body("f = 'x'", start, end, None)
+
+    # Then: The body uses only contract-valid fields
+    assert body["queryType"] == "LOG"  # noqa: S101
+    assert body["tenant"] is True  # noqa: S101
+    assert body["startTime"] == "2026-08-01T00:00:00Z"  # noqa: S101
+    assert body["endTime"] == "2026-08-31T23:59:59Z"  # noqa: S101
+    assert body["queryPriority"] == "HIGH"  # noqa: S101
+    assert body["log"] == {"filter": "f = 'x'", "limit": 100}  # noqa: S101
+    assert "cursor" not in body["log"]  # noqa: S101
+    assert "offset" not in body["log"]  # noqa: S101
+    assert "lastCursor" not in body["log"]  # noqa: S101
+
+    # When: A resumption launch body is built with a cursor
+    resumed = fetcher._build_launch_body("f = 'x'", start, end, "G/xyz")
+
+    # Then: The cursor is carried in the log block
+    assert resumed["log"]["cursor"] == "G/xyz"  # noqa: S101
+
+
+# Scenario: A SaaS fetch posts only to SDL v2 endpoints
+def test_saas_fetch_posts_only_to_sdl_endpoints():
+    """Scenario: A SaaS fetch posts only to SDL v2 endpoints."""
+    # Given: A SaaS SDL fetcher
+    fetcher, session = _given_sdl_fetcher(is_self_hosted=False)
+    # Given: A valid SHA1
+    sha1 = _given_valid_sha1()
+    # Given: One matching row on the first page
+    rows = [
+        _given_row(
+            "c-1",
+            sha1,
+            "e-1",
+            "explorer.exe",
+            "implant.exe",
+            "process_creation",
+            1577836800000,
+        )
+    ]
+    session.post.return_value = _given_launch_response("q-1")
+    session.get.return_value = _given_poll_response("q-1", rows, 1.0, 2, 2)
+
+    # When: I fetch events for the SHA1
+    events = fetcher.fetch_events_for_sha1(sha1)
+
+    # Then: The launch goes to /sdl/v2/api/queries, never to /dv/
+    assert len(events) == 1  # noqa: S101
+    assert session.post.call_count == 1  # noqa: S101
+    launch_url = session.post.call_args.args[0]
+    assert launch_url == "https://s1.example.com/sdl/v2/api/queries"  # noqa: S101
+    launch_body = session.post.call_args.kwargs["json"]
+    assert f"tgt.file.sha1='{sha1}'" in launch_body["log"]["filter"]  # noqa: S101
+    poll_url = session.get.call_args.args[0]
+    assert poll_url == "https://s1.example.com/sdl/v2/api/queries/q-1"  # noqa: S101
+    all_urls = [c.args[0] for c in session.post.call_args_list] + [
+        c.args[0] for c in session.get.call_args_list
+    ]
+    assert all("/dv/" not in url for url in all_urls)  # noqa: S101
+
+
+# Scenario: The service selects the SDL fetcher for a SaaS instance
+def test_service_selects_sdl_fetcher_for_saas():
+    """Scenario: The service selects the SDL fetcher for a SaaS instance."""
+    # Given: A SaaS account listing (one account exposes accountType)
+    mock_get = _given_mock_session_get(account_type_present=True)
+
+    # When: The expectation service is initialized with the probe mocked
+    with patch("requests.Session.get", new=mock_get):
+        service = SentinelOneExpectationService(config=create_test_config())
+
+    # Then: The deep-search backend is the SDL v2 fetcher
+    backend = service.deep_visibility_fetcher
+    assert isinstance(backend, FetcherSDL)  # noqa: S101
+    assert not isinstance(backend, FetcherDeepVisibility)  # noqa: S101
+
+
+# Scenario: The service keeps the DV fetcher for a self-hosted instance
+def test_service_selects_dv_fetcher_for_self_hosted():
+    """Scenario: The service keeps the DV fetcher for a self-hosted instance."""
+    # Given: A self-hosted account listing (no accountType anywhere)
+    mock_get = _given_mock_session_get(account_type_present=False)
+
+    # When: The expectation service is initialized with the probe mocked
+    with patch("requests.Session.get", new=mock_get):
+        service = SentinelOneExpectationService(config=create_test_config())
+
+    # Then: The deep-search backend is the legacy DV fetcher
+    backend = service.deep_visibility_fetcher
+    assert isinstance(backend, FetcherDeepVisibility)  # noqa: S101
+    assert not isinstance(backend, FetcherSDL)  # noqa: S101
+
+
+# Scenario: Polling completes and echoes the forward tag on every poll
+def test_polling_completes_and_echoes_forward_tag():
+    """Scenario: Polling completes and echoes the forward tag on every poll."""
+    # Given: An SDL fetcher
+    fetcher, session = _given_sdl_fetcher()
+    # Given: A valid SHA1
+    sha1 = _given_valid_sha1()
+    # Given: A launch response carrying a mixed-case forward tag
+    session.post.return_value = _given_launch_response(
+        "q-42", forward_tag="G/fwd-tag-77"
+    )
+    # Given: An incomplete first poll and a complete second poll
+    rows = [
+        _given_row(
+            "c-1",
+            sha1,
+            "e-1",
+            "explorer.exe",
+            "implant.exe",
+            "process_creation",
+            1577836800000,
+        )
+    ]
+    incomplete = _given_poll_response("q-42", [], 1.0, steps_completed=1)
+    complete = _given_poll_response("q-42", rows, 1.0, steps_completed=2)
+    session.get.side_effect = [incomplete, complete]
+
+    # When: I fetch with sleeps disabled
+    with patch("time.sleep"):
+        events = fetcher.fetch_events_for_sha1(sha1)
+
+    # Then: The query completed after two polls
+    assert len(events) == 1  # noqa: S101
+    assert session.get.call_count == 2  # noqa: S101
+    # And: The forward tag is echoed in canonical case on every poll
+    first = session.get.call_args_list[0]
+    second = session.get.call_args_list[1]
+    expected_headers = {"x-dataset-query-forward-tag": "G/fwd-tag-77"}
+    assert first.kwargs["headers"] == expected_headers  # noqa: S101
+    assert second.kwargs["headers"] == expected_headers  # noqa: S101
+    # And: lastStepSeen tracks the last observed stepsCompleted
+    assert first.kwargs["params"] == {"lastStepSeen": 0}  # noqa: S101
+    assert second.kwargs["params"] == {"lastStepSeen": 1}  # noqa: S101
+
+
+# Scenario: Pagination resumes with cursors and deduplicates inclusive overlaps
+def test_pagination_resumes_with_cursor_and_dedupes():
+    """Scenario: Pagination resumes with cursors and deduplicates overlaps."""
+    # Given: An SDL fetcher
+    fetcher, session = _given_sdl_fetcher()
+    # Given: Six rows for the target SHA1
+    sha1 = _given_valid_sha1()
+    rows = [
+        _given_row(
+            f"cursor-{i}",
+            sha1,
+            f"evt-{i}",
+            "explorer.exe",
+            "implant.exe",
+            "process_creation",
+            1577836800000 + i,
+        )
+        for i in range(6)
+    ]
+    # Given: Five pages; each resumed page repeats its first row (inclusive)
+    pages = [
+        (rows[0:2], 6.0),
+        (rows[1:3], 5.0),
+        (rows[2:4], 4.0),
+        (rows[3:5], 3.0),
+        (rows[4:6], 2.0),
+    ]
+    session.post.side_effect = [
+        _given_launch_response(f"q-{i + 1}") for i in range(len(pages))
+    ]
+    session.get.side_effect = [
+        _given_poll_response(f"q-{i + 1}", page_rows, est, 2, 2)
+        for i, (page_rows, est) in enumerate(pages)
+    ]
+
+    # When: I fetch all pages
+    events = fetcher.fetch_events_for_sha1(sha1)
+
+    # Then: Paging stopped once the first page's estimate was reached
+    assert session.post.call_count == 5  # noqa: S101
+    assert session.get.call_count == 5  # noqa: S101
+    # And: Inclusive-resumption overlaps were deduplicated by cursor
+    assert len(events) == 6  # noqa: S101
+    assert [e["fileSha1"] for e in events] == [sha1] * 6  # noqa: S101
+    # And: Resumption passed the previous page's last row cursor
+    first_body = session.post.call_args_list[0].kwargs["json"]
+    last_body = session.post.call_args_list[4].kwargs["json"]
+    assert "cursor" not in first_body["log"]  # noqa: S101
+    assert last_body["log"]["cursor"] == "cursor-4"  # noqa: S101
+
+
+# Scenario: A row maps to the Deep-Visibility-shaped event contract
+def test_row_maps_to_deep_visibility_event_contract():
+    """Scenario: A row maps to the Deep-Visibility-shaped event contract."""
+    # Given: An SDL fetcher
+    fetcher, _ = _given_sdl_fetcher()
+    # Given: A row with the verified field vocabulary
+    row = _given_row(
+        "c-1",
+        _given_valid_sha1(),
+        "evt-9",
+        "explorer.exe",
+        "implant.exe",
+        "process_creation",
+        1577836800500,
+    )
+
+    # When: The row is mapped to an event
+    event = fetcher._map_row_to_event(row)
+
+    # Then: Every contract key is populated from the row values
+    assert event["fileSha1"] == _given_valid_sha1()  # noqa: S101
+    assert event["fileSha256"] == "f" * 64  # noqa: S101
+    assert event["fileId"] == "7F8BC31AF4A291CB"  # noqa: S101
+    assert event["parentProcessName"] == "explorer.exe"  # noqa: S101
+    assert event["processName"] == "implant.exe"  # noqa: S101
+    assert event["processCmdline"] == "C:\\Windows\\System32\\implant.exe"  # noqa: S101
+    assert event["parentProcessCmdline"] == "C:\\Windows\\explorer.exe"  # noqa: S101
+    assert event["hostname"] == "kingslanding"  # noqa: S101
+    assert event["eventType"] == "process_creation"  # noqa: S101
+    assert event["eventTime"] == "2020-01-01T00:00:00.500000Z"  # noqa: S101
+    assert event["eventId"] == "evt-9"  # noqa: S101
+    # And: The raw values block is preserved
+    assert event["raw"] is row["values"]  # noqa: S101
+
+
+# Scenario: Row mapping tolerates missing fields
+def test_row_mapping_tolerates_missing_fields():
+    """Scenario: Row mapping tolerates missing fields."""
+    # Given: An SDL fetcher
+    fetcher, _ = _given_sdl_fetcher()
+
+    # When: A row with an empty values block is mapped
+    event = fetcher._map_row_to_event({"cursor": "c-x", "values": {}})
+
+    # Then: Every field degrades to None instead of raising
+    assert event["fileSha1"] is None  # noqa: S101
+    assert event["parentProcessName"] is None  # noqa: S101
+    assert event["eventTime"] is None  # noqa: S101
+    assert event["raw"] == {}  # noqa: S101
+
+    # When: A row with no values block at all is mapped
+    bare = fetcher._map_row_to_event({})
+
+    # Then: It also degrades to all-None fields
+    assert bare["fileSha1"] is None  # noqa: S101
+    assert bare["raw"] == {}  # noqa: S101
+
+
+# Scenario: Batch results group events per requested SHA1
+def test_batch_groups_events_per_requested_sha1():
+    """Scenario: Batch results group events per requested SHA1."""
+    # Given: An SDL fetcher
+    fetcher, session = _given_sdl_fetcher()
+    # Given: Three requested SHA1s
+    sha1s = _given_valid_sha1_list()
+    first, second, third = sha1s
+    # Given: Rows for two requested SHA1s and one unrequested SHA1
+    unrequested = "d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4"
+    rows = [
+        _given_row("c-1", first, "e-1", "p1", "q1", "t1", 1577836800000),
+        _given_row("c-2", first, "e-2", "p1", "q2", "t1", 1577836801000),
+        _given_row("c-3", second, "e-3", "p2", "q3", "t2", 1577836802000),
+        _given_row("c-4", unrequested, "e-4", "p3", "q4", "t3", 1577836803000),
+    ]
+    session.post.return_value = _given_launch_response("q-batch")
+    session.get.return_value = _given_poll_response("q-batch", rows, 4.0, 2, 2)
+
+    # When: I fetch the batch
+    result = fetcher.fetch_events_for_batch_sha1(sha1s)
+
+    # Then: Every requested SHA1 is a key, including the no-match one
+    assert set(result.keys()) == set(sha1s)  # noqa: S101
+    assert len(result[first]) == 2  # noqa: S101
+    assert len(result[second]) == 1  # noqa: S101
+    assert result[third] == []  # noqa: S101
+    # And: The unrequested row was dropped
+    assert sum(len(v) for v in result.values()) == 3  # noqa: S101
+
+
+# Scenario: Single-SHA1 fetch post-filters non-matching rows
+def test_single_sha1_fetch_postfilters_non_matching_rows():
+    """Scenario: Single-SHA1 fetch post-filters non-matching rows."""
+    # Given: An SDL fetcher
+    fetcher, session = _given_sdl_fetcher()
+    # Given: The target SHA1 and a different one
+    target = _given_valid_sha1()
+    other = "b2c3d4e5f6789012345678901234567890abcdef"
+    # Given: A page containing both
+    rows = [
+        _given_row("c-1", target, "e-1", "p", "q", "t", 1577836800000),
+        _given_row("c-2", other, "e-2", "p", "q", "t", 1577836801000),
+        _given_row("c-3", target, "e-3", "p", "q", "t", 1577836802000),
+    ]
+    session.post.return_value = _given_launch_response("q-pf")
+    session.get.return_value = _given_poll_response("q-pf", rows, 3.0, 2, 2)
+
+    # When: I fetch events for the target SHA1
+    events = fetcher.fetch_events_for_sha1(target)
+
+    # Then: Only rows matching the target SHA1 survive
+    assert len(events) == 2  # noqa: S101
+    assert all(e["fileSha1"] == target for e in events)  # noqa: S101
+
+
+# Scenario: A 400 invalid_argument launch error surfaces with its details
+def test_launch_400_invalid_argument_raises_api_error():
+    """Scenario: A 400 invalid_argument launch error surfaces with details."""
+    # Given: An SDL fetcher
+    fetcher, session = _given_sdl_fetcher()
+    # Given: A 400 response in the verified SDL error shape
+    response = Mock()
+    response.status_code = 400
+    response.json.return_value = {
+        "code": "invalid_argument",
+        "message": "Invalid JSON",
+        "details": [{"field": "log.offset", "message": "Cannot deserialize JSON"}],
+    }
+    response.text = str(response.json.return_value)
+    session.post.return_value = response
+
+    # When: I launch a fetch
+    with pytest.raises(SentinelOneAPIError) as excinfo:
+        fetcher.fetch_events_for_sha1(_given_valid_sha1())
+
+    # Then: The error carries the status and the structured details
+    message = str(excinfo.value)
+    assert "SDL query launch" in message  # noqa: S101
+    assert "status 400" in message  # noqa: S101
+    assert "code=invalid_argument" in message  # noqa: S101
+    assert "message=Invalid JSON" in message  # noqa: S101
+    assert "log.offset: Cannot deserialize JSON" in message  # noqa: S101
+
+
+# Scenario: A 404 poll means the query expired
+def test_poll_404_expired_raises_api_error():
+    """Scenario: A 404 poll means the query expired."""
+    # Given: An SDL fetcher
+    fetcher, session = _given_sdl_fetcher()
+    # Given: A successful launch followed by a 404 poll
+    session.post.return_value = _given_launch_response("q-exp")
+    not_found = Mock()
+    not_found.status_code = 404
+    not_found.json.return_value = {"message": "query not found"}
+    not_found.text = "query not found"
+    session.get.return_value = not_found
+
+    # When: I fetch events
+    with pytest.raises(SentinelOneAPIError) as excinfo:
+        fetcher.fetch_events_for_sha1(_given_valid_sha1())
+
+    # Then: The error reports the query as expired
+    assert "expired (HTTP 404)" in str(excinfo.value)  # noqa: S101
+
+
+# Scenario: A 429 is retried with backoff, then succeeds
+def test_429_retries_with_backoff_then_succeeds(caplog: Any):
+    """Scenario: A 429 is retried with backoff, then succeeds."""
+    # Given: An SDL fetcher
+    fetcher, session = _given_sdl_fetcher()
+    # Given: The first launch is rate limited, the retry succeeds
+    rate_limited = Mock()
+    rate_limited.status_code = 429
+    session.post.side_effect = [rate_limited, _given_launch_response("q-rl")]
+    session.get.return_value = _given_poll_response("q-rl", [], 0.0, 2, 2)
+
+    # When: I fetch with sleeps disabled
+    with patch("time.sleep") as mock_sleep:
+        events = fetcher.fetch_events_for_sha1(_given_valid_sha1())
+
+    # Then: The retry succeeded after one 5-second backoff
+    assert events == []  # noqa: S101
+    assert session.post.call_count == 2  # noqa: S101
+    mock_sleep.assert_called_once_with(5)
+    # And: The rate limit was logged as a warning
+    assert any(  # noqa: S101
+        "retry 1/4 in 5s" in record.getMessage()
+        for record in caplog.records
+        if record.levelno == logging.WARNING
+    )
+
+
+# Scenario: Exhausted 429 retries raise an API error
+def test_429_retries_exhausted_raises_api_error():
+    """Scenario: Exhausted 429 retries raise an API error."""
+    # Given: An SDL fetcher
+    fetcher, session = _given_sdl_fetcher()
+    # Given: Every launch is rate limited
+    rate_limited = Mock()
+    rate_limited.status_code = 429
+    session.post.return_value = rate_limited
+
+    # When: I fetch with sleeps disabled
+    with patch("time.sleep"):
+        with pytest.raises(SentinelOneAPIError) as excinfo:
+            fetcher.fetch_events_for_sha1(_given_valid_sha1())
+
+    # Then: The error reports the exhausted retries
+    assert "rate limited" in str(excinfo.value)  # noqa: S101
+    assert "4 retries" in str(excinfo.value)  # noqa: S101
+    # And: The bounded retry budget was respected (initial + 4 retries)
+    assert session.post.call_count == 5  # noqa: S101
+
+
+# Scenario: A network error raises SentinelOneNetworkError
+def test_network_error_raises_network_error():
+    """Scenario: A network error raises SentinelOneNetworkError."""
+    # Given: An SDL fetcher
+    fetcher, session = _given_sdl_fetcher()
+    # Given: The launch connection fails
+    session.post.side_effect = RequestsConnectionError("connection refused")
+
+    # When: I fetch events
+    with pytest.raises(SentinelOneNetworkError) as excinfo:
+        fetcher.fetch_events_for_sha1(_given_valid_sha1())
+
+    # Then: The failure is reported as a network error
+    assert "Network error" in str(excinfo.value)  # noqa: S101
+
+
+# Scenario: Invalid SHA1 input fails before any request is made
+def test_invalid_sha1_raises_validation_error():
+    """Scenario: Invalid SHA1 input fails before any request is made."""
+    # Given: An SDL fetcher
+    fetcher, session = _given_sdl_fetcher()
+
+    # When: I fetch with an empty SHA1
+    with pytest.raises(SentinelOneValidationError):
+        fetcher.fetch_events_for_sha1("")
+
+    # When: I fetch with a non-string SHA1
+    with pytest.raises(SentinelOneValidationError):
+        fetcher.fetch_events_for_sha1(12345)
+
+    # When: I batch-fetch with an empty list
+    with pytest.raises(SentinelOneValidationError):
+        fetcher.fetch_events_for_batch_sha1([])
+
+    # Then: No request was ever made
+    session.post.assert_not_called()
+    session.get.assert_not_called()
+
+
+# Scenario: Absent times default to the configured time window
+def test_default_window_used_when_times_absent():
+    """Scenario: Absent times default to the configured time window."""
+    # Given: An SDL fetcher with a one-hour client time window
+    fetcher, session = _given_sdl_fetcher()
+    # Given: An empty matching response
+    session.post.return_value = _given_launch_response("q-dw")
+    session.get.return_value = _given_poll_response("q-dw", [], 0.0, 2, 2)
+
+    # When: I fetch without explicit times
+    fetcher.fetch_events_for_sha1(_given_valid_sha1())
+
+    # Then: The launch body spans exactly the configured window
+    body = session.post.call_args.kwargs["json"]
+    assert body["startTime"].endswith("Z")  # noqa: S101
+    assert body["endTime"].endswith("Z")  # noqa: S101
+    start = datetime.fromisoformat(body["startTime"].replace("Z", "+00:00"))
+    end = datetime.fromisoformat(body["endTime"].replace("Z", "+00:00"))
+    assert end - start == timedelta(hours=1)  # noqa: S101

--- a/sentinelone/tests/services/test_fetcher_sdl.py
+++ b/sentinelone/tests/services/test_fetcher_sdl.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.structures import CaseInsensitiveDict
 from src.services.exception import (
     SentinelOneAPIError,
     SentinelOneNetworkError,
@@ -58,6 +59,7 @@ def _given_mock_client_api(is_self_hosted: bool) -> Mock:
     client = Mock()
     client.base_url = "https://s1.example.com"
     client.time_window = timedelta(hours=1)
+    client.api_key = "sdl-api-key-123"
     client.is_self_hosted = is_self_hosted
     return client
 
@@ -443,7 +445,10 @@ def test_polling_completes_and_echoes_forward_tag():
     # And: The forward tag is echoed in canonical case on every poll
     first = session.get.call_args_list[0]
     second = session.get.call_args_list[1]
-    expected_headers = {"x-dataset-query-forward-tag": "G/fwd-tag-77"}
+    expected_headers = {
+        "x-dataset-query-forward-tag": "G/fwd-tag-77",
+        "Authorization": "Bearer sdl-api-key-123",
+    }
     assert first.kwargs["headers"] == expected_headers  # noqa: S101
     assert second.kwargs["headers"] == expected_headers  # noqa: S101
     # And: lastStepSeen tracks the last observed stepsCompleted
@@ -773,3 +778,63 @@ def test_default_window_used_when_times_absent():
     start = datetime.fromisoformat(body["startTime"].replace("Z", "+00:00"))
     end = datetime.fromisoformat(body["endTime"].replace("Z", "+00:00"))
     assert end - start == timedelta(hours=1)  # noqa: S101
+
+
+# Scenario: SDL v2 requests authenticate with Bearer, never the classic ApiToken
+def test_sdl_launch_uses_bearer_auth_not_api_token() -> None:
+    """The SDL v2 API requires a Bearer Authorization header.
+
+    Given: An SDL fetcher wired to a client exposing its api_key
+    When: the SDL query is launched
+    Then: the request carries ``Authorization: Bearer <api_key>`` (never ApiToken)
+
+    """
+    fetcher, session = _given_sdl_fetcher(is_self_hosted=False)
+    session.post.return_value = _given_launch_response("q-1")
+
+    fetcher._launch_query({"log": {"filter": "x", "limit": 1}, "queryType": "LOG"})
+
+    sent = session.post.call_args.kwargs.get("headers")
+    assert (
+        sent is not None
+    ), "SDL requests must carry an Authorization header"  # noqa: S101
+    assert sent["Authorization"] == "Bearer sdl-api-key-123"  # noqa: S101
+    assert "ApiToken" not in sent["Authorization"]  # noqa: S101
+
+
+# Scenario: An SDL poll carries Bearer while preserving the echoed forward tag
+def test_sdl_poll_carries_bearer_auth_with_forward_tag() -> None:
+    """Bearer auth is injected alongside the echoed forward-tag header on polls.
+
+    Given: An SDL fetcher wired to a client exposing its api_key
+    When: an SDL query is polled with a forward tag
+    Then: the poll keeps the forward tag AND carries ``Bearer <api_key>``
+
+    """
+    fetcher, session = _given_sdl_fetcher(is_self_hosted=False)
+    session.get.return_value = _given_poll_response("q-1", [], 0.0, 2, 2)
+
+    with patch("time.sleep"):
+        fetcher._poll_query_to_completion("q-1", "G/fwd-tag-1")
+
+    sent = session.get.call_args.kwargs["headers"]
+    assert sent == {
+        "x-dataset-query-forward-tag": "G/fwd-tag-1",
+        "Authorization": "Bearer sdl-api-key-123",
+    }
+
+
+# Scenario: the routing forward tag survives a real (case-insensitive) response
+# headers mapping, not only a plain dict
+def test_extract_forward_tag_from_real_case_insensitive_headers() -> None:
+    """A live requests response exposes headers as a CaseInsensitiveDict, which
+    is a Mapping but not a dict. The routing tag must still be extracted, or the
+    poll is routed to a backend that does not own the query and 404s with
+    'token not found'.
+    """
+    fetcher, _ = _given_sdl_fetcher(is_self_hosted=False)
+    response = Mock()
+    response.headers = CaseInsensitiveDict(
+        {"x-dataset-query-forward-tag": "G/fwd-live"}
+    )
+    assert fetcher._extract_forward_tag(response) == "G/fwd-live"  # noqa: S101

--- a/sentinelone/tests/services/test_fetcher_threat_events.py
+++ b/sentinelone/tests/services/test_fetcher_threat_events.py
@@ -1,6 +1,9 @@
 """Essential tests for SentinelOne Threat Events Fetcher service - Gherkin GWT Format."""
 
+from unittest.mock import Mock, call, patch
+
 import pytest
+import src.services.fetcher_threat_events as fetcher_threat_events_module
 from src.services.exception import SentinelOneValidationError
 from src.services.fetcher_threat_events import FetcherThreatEvents
 from tests.gwt_shared import (
@@ -48,8 +51,6 @@ def test_fetch_events_for_threat_successfully():
     threat = _given_threat_for_event_fetching()
 
     # When: I fetch events for the threat (with mocked API)
-    from unittest.mock import Mock, patch
-
     mock_response = Mock()
     mock_response.json.return_value = {
         "data": [
@@ -67,6 +68,103 @@ def test_fetch_events_for_threat_successfully():
 
     # Then: Events should be returned successfully
     _then_events_returned_successfully(events)
+
+
+# Scenario: Fetch all threat-event pages and retain a later-page implant marker
+def test_fetch_events_follows_next_cursor_until_null_and_returns_later_marker():
+    """Scenario: Cursor pagination returns all events, including a late marker."""
+    # Given: Six full pages and one short final page total 646 events
+    fetcher = _given_valid_threat_events_fetcher()
+    threat = _given_threat_for_event_fetching()
+    pages = []
+    expected_events = []
+    for page_number in range(1, 8):
+        page_size = 100 if page_number <= 6 else 46
+        events = [
+            {
+                "id": f"event-{page_number}-{event_number}",
+                "parentProcessName": "ordinary.exe",
+            }
+            for event_number in range(page_size)
+        ]
+        expected_events.extend(events)
+        next_cursor = f"cursor-{page_number}" if page_number <= 6 else None
+        pages.append(_given_events_page(events, next_cursor))
+
+    # And: The implant marker exists only on the final page
+    marker = {"id": "event-7-45", "parentProcessName": "oaev-implant-later.exe"}
+    pages[-1].json.return_value["data"][-1] = marker
+    expected_events[-1] = marker
+    # When: Threat events are fetched
+    with patch.object(fetcher.client_api.session, "get", side_effect=pages) as mock_get:
+        events = fetcher.fetch_events_for_threat(threat, limit=100)
+
+    # Then: Every page is returned and later requests carry the prior cursor
+    assert events == expected_events  # noqa: S101
+    assert marker in events  # noqa: S101
+    endpoint = (
+        f"{fetcher.client_api.base_url}/web/api/v2.1/threats/"
+        f"{threat.threat_id}/explore/events"
+    )
+    expected_calls = [call(endpoint, params={"limit": 100}, timeout=30)]
+    expected_calls.extend(
+        call(
+            endpoint,
+            params={"limit": 100, "cursor": f"cursor-{page_number}"},
+            timeout=30,
+        )
+        for page_number in range(1, 7)
+    )
+    assert mock_get.call_args_list == expected_calls  # noqa: S101
+
+
+# Scenario: A repeated cursor terminates pagination safely
+def test_fetch_events_stops_when_next_cursor_does_not_advance():
+    """Scenario: A repeated next cursor cannot create an infinite request loop."""
+    # Given: The second page repeats the cursor used to request it
+    fetcher = _given_valid_threat_events_fetcher()
+    threat = _given_threat_for_event_fetching()
+    pages = [
+        _given_events_page([{"id": "event-1"}], "cursor-1"),
+        _given_events_page([{"id": "event-2"}], "cursor-1"),
+    ]
+
+    # When: Threat events are fetched
+    with patch.object(fetcher.client_api.session, "get", side_effect=pages) as mock_get:
+        events = fetcher.fetch_events_for_threat(threat)
+
+    # Then: Both reached pages are retained and no third request is attempted
+    assert events == [{"id": "event-1"}, {"id": "event-2"}]  # noqa: S101
+    assert mock_get.call_count == 2  # noqa: S101
+
+
+# Scenario: Threat-event pagination has a defensive page cap
+def test_fetch_events_stops_at_defensive_page_cap(monkeypatch):
+    """Scenario: Ever-advancing cursors cannot cause unbounded requests."""
+    # Given: The repository-standard page cap is reduced and every page advances
+    monkeypatch.setattr(fetcher_threat_events_module, "MAX_PAGES", 3, raising=False)
+    fetcher = _given_valid_threat_events_fetcher()
+    threat = _given_threat_for_event_fetching()
+
+    def advancing_page(*_args, **_kwargs):
+        page_number = mock_get.call_count
+        return _given_events_page(
+            [{"id": f"event-{page_number}"}], f"cursor-{page_number}"
+        )
+
+    # When: Threat events are fetched
+    with patch.object(
+        fetcher.client_api.session, "get", side_effect=advancing_page
+    ) as mock_get:
+        events = fetcher.fetch_events_for_threat(threat)
+
+    # Then: Pagination stops exactly at the configured defensive cap
+    assert events == [
+        {"id": "event-1"},
+        {"id": "event-2"},
+        {"id": "event-3"},
+    ]  # noqa: S101
+    assert mock_get.call_count == 3  # noqa: S101
 
 
 # --------
@@ -117,6 +215,18 @@ def _given_threat_for_event_fetching():
 
     """
     return given_threat_with_complete_data()
+
+
+# Given: An API page of threat events with pagination metadata
+def _given_events_page(events, next_cursor):
+    """Create a successful threat-events response page."""
+    response = Mock()
+    response.json.return_value = {
+        "data": events,
+        "pagination": {"nextCursor": next_cursor},
+    }
+    response.raise_for_status.return_value = None
+    return response
 
 
 # Given: Mock API returns event data

--- a/sentinelone/tests/services/test_fetcher_unified_alerts.py
+++ b/sentinelone/tests/services/test_fetcher_unified_alerts.py
@@ -1,0 +1,204 @@
+"""Tests for the SentinelOne Unified Alerts fetcher - Gherkin GWT format."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+import pytest
+from requests.exceptions import ConnectionError as RequestsConnectionError
+
+from src.services.exception import SentinelOneAPIError, SentinelOneNetworkError
+from src.services.fetcher_unified_alerts import FetcherUnifiedAlerts
+
+IMPLANT = "oaev-implant-91b43a50-910b-4fb3-aae8-a9d70e6f6bd4-agent-a7dbf250"
+
+
+def _given_fetcher() -> tuple[FetcherUnifiedAlerts, Mock]:
+    """Create a Unified Alerts fetcher wired to a mock session.
+
+    Returns:
+        Tuple of (fetcher, mock session).
+
+    """
+    session = Mock()
+    client = Mock()
+    client.base_url = "https://s1.example.com"
+    client.api_key = "bearer-key-123"
+    client.session = session
+    return FetcherUnifiedAlerts(client), session
+
+
+def _response(status: int, payload: dict) -> Mock:
+    """Build a mock HTTP response.
+
+    Args:
+        status: HTTP status code.
+        payload: JSON body.
+
+    Returns:
+        Mock response.
+
+    """
+    r = Mock()
+    r.status_code = status
+    r.json.return_value = payload
+    r.text = str(payload)
+    return r
+
+
+def _list_page(nodes: list[dict], has_next: bool = False) -> dict:
+    """Build an alerts connection page.
+
+    Args:
+        nodes: Alert nodes.
+        has_next: Whether another page follows.
+
+    Returns:
+        GraphQL response body for the alerts list query.
+
+    """
+    return {
+        "data": {
+            "alerts": {
+                "pageInfo": {"hasNextPage": has_next, "endCursor": "c1"},
+                "edges": [{"node": n} for n in nodes],
+            }
+        }
+    }
+
+
+def _detail(raw: object) -> dict:
+    """Build an alert detail response carrying rawData.
+
+    Args:
+        raw: The rawData value.
+
+    Returns:
+        GraphQL response body for the detail query.
+
+    """
+    return {"data": {"alert": {"rawData": raw}}}
+
+
+def _window() -> tuple[datetime, datetime]:
+    """Return a valid (start, end) window.
+
+    Returns:
+        Tuple of two datetimes an hour apart.
+
+    """
+    end = datetime(2026, 9, 11, 14, 0, tzinfo=timezone.utc)
+    return end - timedelta(hours=1), end
+
+
+# Scenario: a behavioral alert is mapped to a threat carrying the implant name
+def test_behavioral_alert_maps_to_threat_with_implant_event():
+    """Scenario: an alert's implant name is recovered from rawData."""
+    fetcher, session = _given_fetcher()
+    node = {
+        "id": "alert-1",
+        "name": "Potential Mimikatz Execution",
+        "detectedAt": "2026-09-11T13:44:48Z",
+        "status": "NEW",
+        "result": None,
+        "assets": [{"name": "meereen", "osType": "WINDOWS"}],
+        "process": {"parentName": None, "cmdLine": "powershell ..."},
+    }
+    session.post.side_effect = [
+        _response(200, _list_page([node])),
+        _response(
+            200,
+            _detail(
+                {
+                    "process": {"name": "PowerShell.EXE"},
+                    "cmd": f"{IMPLANT}.exe launched child",
+                }
+            ),
+        ),
+    ]
+
+    start, end = _window()
+    threats, events = fetcher.fetch_alert_threats(start, end)
+
+    assert len(threats) == 1
+    assert threats[0].threat_id == "alert-1"
+    assert threats[0].hostname == "meereen"
+    assert threats[0].is_mitigated is False
+    parents = [e["parentProcessName"] for e in events["alert-1"]]
+    assert f"{IMPLANT}.exe" in parents
+
+
+# Scenario: a MITIGATED alert is marked as prevented
+def test_mitigated_alert_is_marked_mitigated():
+    """Scenario: result=MITIGATED sets is_mitigated on the mapped threat."""
+    fetcher, session = _given_fetcher()
+    node = {
+        "id": "alert-2",
+        "result": "MITIGATED",
+        "assets": [{"name": "demo-vm"}],
+        "process": {},
+    }
+    session.post.side_effect = [
+        _response(200, _list_page([node])),
+        _response(200, _detail(f"trace {IMPLANT}")),
+    ]
+
+    threats, _ = fetcher.fetch_alert_threats(*_window())
+
+    assert threats[0].is_mitigated is True
+
+
+# Scenario: an alert with no recoverable implant yields no matching event
+def test_alert_without_implant_has_no_events():
+    """Scenario: no implant in rawData -> empty events (no false positive)."""
+    fetcher, session = _given_fetcher()
+    node = {"id": "alert-3", "assets": [{"name": "host"}], "process": {}}
+    session.post.side_effect = [
+        _response(200, _list_page([node])),
+        _response(200, _detail("nothing relevant here")),
+    ]
+
+    threats, events = fetcher.fetch_alert_threats(*_window())
+
+    assert len(threats) == 1
+    assert events.get("alert-3", []) == []
+
+
+# Scenario: pagination follows the connection cursor
+def test_pagination_follows_cursor():
+    """Scenario: hasNextPage drives a second list page."""
+    fetcher, session = _given_fetcher()
+    n1 = {"id": "a1", "assets": [{"name": "h1"}], "process": {}}
+    n2 = {"id": "a2", "assets": [{"name": "h2"}], "process": {}}
+    # All list pages are walked first, then rawData is fetched per node.
+    session.post.side_effect = [
+        _response(200, _list_page([n1], has_next=True)),
+        _response(200, _list_page([n2], has_next=False)),
+        _response(200, _detail(IMPLANT)),
+        _response(200, _detail(IMPLANT)),
+    ]
+
+    threats, _ = fetcher.fetch_alert_threats(*_window())
+
+    assert {t.threat_id for t in threats} == {"a1", "a2"}
+
+
+# Scenario: a transport failure raises a transient network error
+def test_transport_failure_raises_network_error():
+    """Scenario: a connection drop surfaces as SentinelOneNetworkError."""
+    fetcher, session = _given_fetcher()
+    session.post.side_effect = RequestsConnectionError("boom")
+
+    with pytest.raises(SentinelOneNetworkError):
+        fetcher.fetch_alert_threats(*_window())
+
+
+# Scenario: a GraphQL errors block raises an API error
+def test_graphql_errors_raise_api_error():
+    """Scenario: a GraphQL validation error surfaces as SentinelOneAPIError."""
+    fetcher, session = _given_fetcher()
+    session.post.return_value = _response(
+        200, {"errors": [{"message": "FieldUndefined"}]}
+    )
+
+    with pytest.raises(SentinelOneAPIError):
+        fetcher.fetch_alert_threats(*_window())

--- a/sentinelone/tests/services/test_fetcher_unified_alerts.py
+++ b/sentinelone/tests/services/test_fetcher_unified_alerts.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock
 
 import pytest
 from requests.exceptions import ConnectionError as RequestsConnectionError
-
 from src.services.exception import SentinelOneAPIError, SentinelOneNetworkError
 from src.services.fetcher_unified_alerts import FetcherUnifiedAlerts
 

--- a/sentinelone/tests/services/test_self_hosted_detection.py
+++ b/sentinelone/tests/services/test_self_hosted_detection.py
@@ -1,0 +1,212 @@
+"""Essential tests for self-hosted detection on the SentinelOne Client API service - Gherkin GWT Format."""
+
+import logging
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+from requests.exceptions import HTTPError
+from src.models.configs.config_loader import ConfigLoader
+from src.services.client_api import SentinelOneClientAPI
+from tests.services.fixtures.factories import create_test_config
+
+# --------
+# Fixtures
+# --------
+
+
+@pytest.fixture(autouse=True)
+def mock_logging() -> logging.Logger:
+    """Shadow the services conftest ``mock_logging`` fixture for this module.
+
+    The conftest autouse fixture replaces every named logger with a shared
+    ``Mock``; log calls on that mock never reach the real logging hierarchy,
+    so the ``caplog`` fixture cannot observe them. The probe-failure scenario
+    must emit its warning through the real loggers for ``caplog`` to capture
+    it, so this module-level fixture shadows the conftest one and restores
+    real logging for this module only.
+
+    Yields:
+        The real root logger.
+
+    """
+    yield logging.getLogger()
+
+
+# --------
+# Scenarios
+# --------
+
+
+# Scenario: Account listing with an accountType field resolves SaaS
+def test_account_listing_with_account_type_resolves_saas():
+    """Scenario: Account listing with an accountType field resolves SaaS."""
+    # Given: A test configuration
+    config = _given_config()
+    # Given: An account listing response containing an accountType field
+    mock_get = _given_mock_http_with_account_listing(
+        [
+            {
+                "id": "saas-account-1",
+                "name": "SaaS Trial Account",
+                "accountType": "Trial",
+                "creator": "SentinelOne",
+                "billingMode": "Subscription",
+            }
+        ]
+    )
+
+    # When: I initialize the client API with the HTTP layer mocked
+    client = _when_initialize_client_api_with_http_mock(config, mock_get)
+
+    # Then: The probe runs once and the resolved value is False (SaaS)
+    _then_self_hosted_resolved(client, mock_get, expected=False)
+
+
+# Scenario: Account listing without an accountType field resolves self-hosted
+def test_account_listing_without_account_type_resolves_self_hosted():
+    """Scenario: Account listing without an accountType field resolves self-hosted."""
+    # Given: A test configuration
+    config = _given_config()
+    # Given: An account listing response without any accountType field
+    mock_get = _given_mock_http_with_account_listing(
+        [
+            {
+                "id": "self-hosted-account-1",
+                "name": "On Prem Account",
+            }
+        ]
+    )
+
+    # When: I initialize the client API with the HTTP layer mocked
+    client = _when_initialize_client_api_with_http_mock(config, mock_get)
+
+    # Then: The probe runs once and the resolved value is True (self-hosted)
+    _then_self_hosted_resolved(client, mock_get, expected=True)
+
+
+# Scenario: HTTP error during the probe defaults to SaaS with a warning
+def test_probe_http_error_defaults_saas_with_warning(caplog):  # type: ignore
+    """Scenario: HTTP error during the probe defaults to SaaS with a warning."""
+    # Given: A test configuration
+    config = _given_config()
+    # Given: The account listing endpoint raises an HTTP error
+    mock_get = _given_mock_http_with_error(
+        HTTPError("404 Client Error: Not Found for url: /web/api/v2.1/accounts")
+    )
+
+    # When: I initialize the client API with the HTTP layer mocked
+    client = _when_initialize_client_api_with_http_mock(config, mock_get)
+
+    # Then: The probe ran, the resolved value is False (SaaS), and a warning was logged
+    _then_self_hosted_resolved(client, mock_get, expected=False)
+    _then_probe_failure_warning_logged(caplog)
+
+
+# --------
+# Given Methods
+# --------
+
+
+# Given: A test configuration
+def _given_config() -> ConfigLoader:
+    """Create the standard test configuration.
+
+    Returns:
+        ConfigLoader instance for the SentinelOne tests.
+
+    """
+    return create_test_config()
+
+
+# Given: A mocked HTTP layer returning an account listing response
+def _given_mock_http_with_account_listing(accounts: list[dict]) -> Mock:
+    """Create a mock session get returning an account listing body.
+
+    Args:
+        accounts: The account objects returned in the "data" field.
+
+    Returns:
+        Mock replacing the session HTTP get method.
+
+    """
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {"data": accounts}
+    return Mock(return_value=mock_response)
+
+
+# Given: A mocked HTTP layer raising an HTTP error
+def _given_mock_http_with_error(error: Exception) -> Mock:
+    """Create a mock session get raising an HTTP error.
+
+    Args:
+        error: The HTTP error to raise.
+
+    Returns:
+        Mock replacing the session HTTP get method.
+
+    """
+    return Mock(side_effect=error)
+
+
+# --------
+# When Methods
+# --------
+
+
+# When: I initialize the client API with the HTTP layer mocked
+def _when_initialize_client_api_with_http_mock(
+    config: ConfigLoader, mock_get: Mock
+) -> SentinelOneClientAPI:
+    """Initialize the client API with the session HTTP get method mocked.
+
+    Args:
+        config: Configuration object to use.
+        mock_get: Mock replacing the session HTTP get method.
+
+    Returns:
+        Initialized SentinelOneClientAPI instance.
+
+    """
+    with patch("requests.Session.get", new=mock_get):
+        return SentinelOneClientAPI(config=config)
+
+
+# --------
+# Then Methods
+# --------
+
+
+# Then: The self-hosted flag is resolved as expected after a single probe
+def _then_self_hosted_resolved(
+    client: SentinelOneClientAPI, mock_get: Mock, expected: bool
+) -> None:
+    """Verify the resolved is_self_hosted value and probe behaviour.
+
+    Args:
+        client: The client API instance to verify.
+        mock_get: The mock used for the session HTTP get method.
+        expected: The expected resolved boolean value.
+
+    """
+    assert client.is_self_hosted is expected  # noqa: S101
+    assert mock_get.call_count == 1  # noqa: S101
+
+
+# Then: The probe failure was logged as a warning
+def _then_probe_failure_warning_logged(caplog: Any) -> None:
+    """Verify the probe failure was logged as a warning.
+
+    Args:
+        caplog: Pytest fixture capturing log records.
+
+    """
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.levelno >= logging.WARNING
+    ]
+    assert any(  # noqa: S101
+        "Self-hosted probe failed" in message for message in messages
+    )

--- a/sentinelone/tests/test_transient_threat_fetch.py
+++ b/sentinelone/tests/test_transient_threat_fetch.py
@@ -1,0 +1,94 @@
+"""BDD: transient SentinelOne threat-fetch failure must not emit a negative verdict.
+
+A transient transport failure (network drop / 5xx / 429) must leave the
+expectation unresolved (pending) for the retry-window rule, rather than
+emitting a "Not Detected" / "Not Prevented" update.
+
+RED: this fails against the current implementation, which collapses every
+fetch failure into a negative verdict and thereby resolves the expectation.
+"""
+
+import uuid
+from unittest import mock
+
+import requests
+from pyoaev.apis.inject_expectation.model import DetectionExpectation
+from pyoaev.apis.inject_expectation.model.expectation import ExpectationSignature
+from pyoaev.signatures.types import SignatureTypes
+from src.collector.expectation_handler import GenericExpectationHandler
+from src.collector.expectation_manager import GenericExpectationManager
+from src.services.expectation_service import SentinelOneExpectationService
+from tests.services.fixtures.factories import create_test_config
+
+
+def _build_expectation(cls, end_value: str = "2024-01-15T00:00:00Z"):
+    """Build a real expectation (survives the manager's isinstance filter).
+
+    The manager only processes real Detection/Prevention expectation models, so a
+    plain Mock would be silently filtered out. A valid UUID id and an end_date
+    signature are required to survive batch creation (strict end_date is on).
+    """
+    end_sig = ExpectationSignature(
+        type=SignatureTypes.SIG_TYPE_END_DATE, value=end_value
+    )
+    return cls(
+        inject_expectation_id=uuid.uuid4(),
+        inject_expectation_signatures=[end_sig],
+        api_client=mock.MagicMock(),
+    )
+
+
+def _build_manager(expectation):
+    """Wire the real service -> handler -> manager over a mocked OpenAEV client."""
+    service = SentinelOneExpectationService(config=create_test_config())
+    handler = GenericExpectationHandler(service_provider=service)
+    mock_oaev = mock.MagicMock()
+    mock_oaev.inject_expectation.expectations_models_for_source.return_value = [
+        expectation
+    ]
+    manager = GenericExpectationManager(
+        oaev_api=mock_oaev,
+        collector_id="test-collector",
+        expectation_handler=handler,
+    )
+    return service, manager, mock_oaev
+
+
+def _transient_network_error(service):
+    """Simulate a transient transport failure at the network boundary."""
+    return mock.patch.object(
+        service.client_api.session,
+        "get",
+        side_effect=requests.exceptions.ConnectionError(
+            "simulated transient network failure"
+        ),
+    )
+
+
+def _negative_verdict_emitted(mock_oaev, expectation_id: str) -> bool:
+    """True if the manager emitted a negative verdict for the expectation id."""
+    if not mock_oaev.inject_expectation.bulk_update.called:
+        return False
+    bulk = mock_oaev.inject_expectation.bulk_update.call_args.kwargs.get(
+        "inject_expectation_input_by_id"
+    )
+    entry = (bulk or {}).get(expectation_id)
+    return bool(entry) and (
+        entry.get("is_success") is False
+        or entry.get("result") in ("Not Detected", "Not Prevented")
+    )
+
+
+def test_transient_network_error_does_not_emit_negative_verdict():
+    expectation = _build_expectation(DetectionExpectation)
+    service, manager, mock_oaev = _build_manager(expectation)
+
+    with _transient_network_error(service):
+        manager.process_expectations(mock.MagicMock())
+
+    assert not _negative_verdict_emitted(
+        mock_oaev, str(expectation.inject_expectation_id)
+    ), (
+        "Transient network failure must leave the expectation pending, "
+        "not emit a negative verdict."
+    )  # noqa: S101

--- a/sentinelone/tests/test_transient_threat_fetch_degrade.py
+++ b/sentinelone/tests/test_transient_threat_fetch_degrade.py
@@ -1,0 +1,246 @@
+"""BDD: transient SentinelOne threat-fetch failures degrade after the retry window.
+
+The retry rule is time-based, not count-based: the first failed attempt opens
+a 10-minute retry window anchored at that moment; every collector cycle whose
+elapsed time since the first attempt is within the window holds the
+expectation pending (no verdict, re-fetched next cycle); the first cycle
+after the window is the final attempt, which degrades to a negative verdict
+("Not Detected" / "Not Prevented", is_success=False) instead of hanging
+forever.
+
+The cycle cadence is the collector's period; the rule only depends on
+elapsed time:
+
+    P1M: 1 opening + 10 in-window (t=1..10) + 1 final (t=11) = 12 attempts
+    P2M: 1 opening + 5 in-window (t=2..10) + 1 final (t=12) = 7 attempts
+    P1H: 1 opening + 0 in-window + 1 final (t=60) = 2 attempts
+
+The pending results are is_valid=False/is_pending=True and pass through the
+retry-window loop (_update_failures): in-window results are removed (no
+verdict, re-fetched next cycle); once the window has elapsed the result
+survives on the final attempt and degrades.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+import requests
+from pyoaev.apis.inject_expectation.model import DetectionExpectation
+from pyoaev.apis.inject_expectation.model.expectation import ExpectationSignature
+from pyoaev.signatures.types import SignatureTypes
+from src.collector.expectation_handler import GenericExpectationHandler
+from src.collector.expectation_manager import GenericExpectationManager
+from src.services.expectation_service import SentinelOneExpectationService
+from tests.services.fixtures.factories import create_test_config
+
+T0 = datetime(2024, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
+
+
+class _FakeClock:
+    """A wall clock that only moves when the test advances it."""
+
+    def __init__(self, start: datetime = T0):
+        self.now = start
+
+    def advance(self, amount: timedelta) -> None:
+        self.now = self.now + amount
+
+
+def _build_expectation(end_value: str = "2024-01-15T00:00:00Z"):
+    """Build a real Detection expectation that survives batch creation.
+
+    Needs a valid UUID id and an end_date signature (strict end_date is on).
+    """
+    end_sig = ExpectationSignature(
+        type=SignatureTypes.SIG_TYPE_END_DATE, value=end_value
+    )
+    return DetectionExpectation(
+        inject_expectation_id=uuid.uuid4(),
+        inject_expectation_signatures=[end_sig],
+        api_client=mock.MagicMock(),
+    )
+
+
+def _transient_network_error(service):
+    """Simulate a transient transport failure at the network boundary."""
+    return mock.patch.object(
+        service.client_api.session,
+        "get",
+        side_effect=requests.exceptions.ConnectionError(
+            "simulated transient network failure"
+        ),
+    )
+
+
+def _patched_clock(clock: _FakeClock):
+    """Pin the service's retry-window clock to the fake clock."""
+    return mock.patch.object(
+        SentinelOneExpectationService, "_now", side_effect=lambda: clock.now
+    )
+
+
+def _negative_verdict_emitted(mock_oaev, expectation_id: str) -> bool:
+    """True if the manager emitted a negative verdict for the expectation id."""
+    if not mock_oaev.inject_expectation.bulk_update.called:
+        return False
+    bulk = mock_oaev.inject_expectation.bulk_update.call_args.kwargs.get(
+        "inject_expectation_input_by_id"
+    )
+    entry = (bulk or {}).get(expectation_id)
+    return bool(entry) and (
+        entry.get("is_success") is False
+        or entry.get("result") in ("Not Detected", "Not Prevented")
+    )
+
+
+def test_transient_failures_degrade_after_retry_window_one_minute_cadence():
+    """P1M: 1 opening attempt + 10 in-window + 1 final = 12 attempts."""
+    expectation = _build_expectation()
+    service = SentinelOneExpectationService(config=create_test_config())
+    detection_helper = mock.MagicMock()
+    expectation_id = str(expectation.inject_expectation_id)
+
+    assert service.retry_window == timedelta(
+        minutes=10
+    ), "Default retry window must be 10 minutes."
+
+    clock = _FakeClock()
+    attempts = 0
+    with _patched_clock(clock), _transient_network_error(service):
+        # Attempt 1 (t=0): opens the retry window, no verdict.
+        results, _ = service.handle_batch_expectations([expectation], detection_helper)
+        attempts += 1
+        assert not results, "Opening attempt must hold pending, emit no verdict."
+
+        # t=1..10: elapsed <= 10 min -> in window, still no verdict.
+        for _ in range(10):
+            clock.advance(timedelta(minutes=1))
+            results, _ = service.handle_batch_expectations(
+                [expectation], detection_helper
+            )
+            attempts += 1
+            assert not results, (
+                f"In-window transient failure (attempt {attempts}) must hold "
+                "pending, emit no verdict."
+            )
+
+        # t=11: window elapsed -> final attempt degrades to a verdict.
+        clock.advance(timedelta(minutes=1))
+        results, _ = service.handle_batch_expectations([expectation], detection_helper)
+        attempts += 1
+
+    assert attempts == 12, f"P1M cadence must make 12 attempts, got {attempts}"
+    assert len(results) == 1, (
+        "The final attempt must emit exactly one verdict, " f"got {len(results)}"
+    )
+    assert results[0].expectation_id == expectation_id
+    assert results[0].is_valid is False, (
+        "After the retry window the expectation must degrade to a "
+        "negative verdict (is_valid=False)."
+    )
+    assert results[0].is_pending is True
+
+
+def test_transient_failures_degrade_after_retry_window_two_minute_cadence():
+    """P2M: 1 opening attempt + 5 in-window (t=2..10) + 1 final (t=12) = 7."""
+    expectation = _build_expectation()
+    service = SentinelOneExpectationService(config=create_test_config())
+    detection_helper = mock.MagicMock()
+    expectation_id = str(expectation.inject_expectation_id)
+
+    clock = _FakeClock()
+    attempts = 0
+    with _patched_clock(clock), _transient_network_error(service):
+        # Attempt 1 (t=0): opens the retry window, no verdict.
+        results, _ = service.handle_batch_expectations([expectation], detection_helper)
+        attempts += 1
+        assert not results, "Opening attempt must hold pending, emit no verdict."
+
+        # t=2..10: elapsed <= 10 min -> in window, still no verdict.
+        for _ in range(5):
+            clock.advance(timedelta(minutes=2))
+            results, _ = service.handle_batch_expectations(
+                [expectation], detection_helper
+            )
+            attempts += 1
+            assert not results, (
+                f"In-window transient failure (attempt {attempts}) must hold "
+                "pending, emit no verdict."
+            )
+
+        # t=12: window elapsed -> final attempt degrades to a verdict.
+        clock.advance(timedelta(minutes=2))
+        results, _ = service.handle_batch_expectations([expectation], detection_helper)
+        attempts += 1
+
+    assert attempts == 7, f"P2M cadence must make 7 attempts, got {attempts}"
+    assert len(results) == 1
+    assert results[0].expectation_id == expectation_id
+    assert results[0].is_valid is False
+    assert results[0].is_pending is True
+
+
+def test_transient_failures_degrade_after_retry_window_one_hour_cadence():
+    """P1H: 1 opening attempt + 0 in-window + 1 final (next run at t=60)
+    = 2 attempts."""
+    expectation = _build_expectation()
+    service = SentinelOneExpectationService(config=create_test_config())
+    detection_helper = mock.MagicMock()
+    expectation_id = str(expectation.inject_expectation_id)
+
+    clock = _FakeClock()
+    attempts = 0
+    with _patched_clock(clock), _transient_network_error(service):
+        # Attempt 1 (t=0): opens the retry window, no verdict.
+        results, _ = service.handle_batch_expectations([expectation], detection_helper)
+        attempts += 1
+        assert not results, "Opening attempt must hold pending, emit no verdict."
+
+        # t=60: next collector run, far past the window -> final attempt.
+        clock.advance(timedelta(hours=1))
+        results, _ = service.handle_batch_expectations([expectation], detection_helper)
+        attempts += 1
+
+    assert attempts == 2, f"P1H cadence must make 2 attempts, got {attempts}"
+    assert len(results) == 1
+    assert results[0].expectation_id == expectation_id
+    assert results[0].is_valid is False
+    assert results[0].is_pending is True
+
+
+def test_transient_failures_degrade_emits_negative_verdict_through_manager():
+    """11 in-window service-level attempts emit no verdict; the first
+    manager cycle after the window emits the negative verdict."""
+    expectation = _build_expectation()
+    service = SentinelOneExpectationService(config=create_test_config())
+    handler = GenericExpectationHandler(service_provider=service)
+    mock_oaev = mock.MagicMock()
+    mock_oaev.inject_expectation.expectations_models_for_source.return_value = [
+        expectation
+    ]
+    manager = GenericExpectationManager(
+        oaev_api=mock_oaev,
+        collector_id="test-collector",
+        expectation_handler=handler,
+    )
+    expectation_id = str(expectation.inject_expectation_id)
+    detection_helper = mock.MagicMock()
+
+    clock = _FakeClock()
+    with _patched_clock(clock), _transient_network_error(service):
+        # t=0..10: 11 attempts, all within the window -> no verdict.
+        for _ in range(11):
+            results, _ = service.handle_batch_expectations(
+                [expectation], detection_helper
+            )
+            assert not results, "In-window transient failures must emit no verdict."
+            clock.advance(timedelta(minutes=1))
+
+        # t=11: driven through the full manager path -> final attempt.
+        manager.process_expectations(detection_helper)
+
+    assert _negative_verdict_emitted(mock_oaev, expectation_id), (
+        "After the retry window the manager must emit a negative verdict "
+        "(Not Detected / is_success=False), not hang the expectation forever."
+    )

--- a/sentinelone/tests/unit/services/test_expectation_service.py
+++ b/sentinelone/tests/unit/services/test_expectation_service.py
@@ -41,8 +41,8 @@ class TestSentinelOneExpectationService(unittest.TestCase):
         self.assertEqual(
             service.deep_visibility_fetcher, m_fetcher_deep_visibility.return_value
         )
-        self.assertIsInstance(service.failure_tracker, module.defaultdict)
-        self.assertEqual(service.max_failure, 5)
+        self.assertIsInstance(service.first_attempt_at, dict)
+        self.assertEqual(service.retry_window, config.sentinelone.retry_window)
         m_api.assert_called_once_with(config)
         m_converter.assert_called_once()
         m_fetcher_threat.assert_called_once_with(m_api.return_value)
@@ -62,6 +62,44 @@ class TestSentinelOneExpectationService(unittest.TestCase):
                 module.SignatureTypes.SIG_TYPE_END_DATE,
             ],
         )
+
+    def test_expectation_does_not_match_when_signature_data_is_missing(
+        self,
+        _m_api,
+        m_converter,
+        *_,
+    ):
+        """A required signature with no converted data is a clean non-match."""
+        config = MagicMock()
+        service = module.SentinelOneExpectationService(config=config)
+        service.logger = MagicMock()
+
+        expectation = MagicMock()
+        signature = MagicMock()
+        signature.type = module.SignatureTypes.SIG_TYPE_PARENT_PROCESS_NAME
+        signature.value = "expected-parent.exe"
+        expectation.inject_expectation_signatures = [signature]
+
+        threat = MagicMock()
+        threat.threat_id = "threat-without-parent-process"
+        m_converter.return_value.convert_threats_to_oaev.return_value = [
+            {
+                "target_hostname_address": {
+                    "type": "simple",
+                    "data": ["host.example.com"],
+                }
+            }
+        ]
+        detection_helper = MagicMock()
+
+        result = service._expectation_matches_threat_data(
+            expectation, threat, [], detection_helper
+        )
+
+        self.assertFalse(result)
+        logged_calls = " ".join(str(call) for call in service.logger.method_calls)
+        self.assertNotIn("KeyError", logged_calls)
+        detection_helper.match_alert_elements.assert_not_called()
 
     @patch.object(module.SentinelOneExpectationService, "_process_expectation_batch")
     @patch.object(module.SentinelOneExpectationService, "_create_expectation_batches")
@@ -108,6 +146,11 @@ class TestSentinelOneExpectationService(unittest.TestCase):
 
     @patch.object(module, "SignatureExtractor")
     def test_get_fetch_time_window_with_start_date(self, m_signature_extractor, *_):
+        """A valid start date anchors the window start; the window ends at
+        now.
+
+        The signature end date is no longer read for this window.
+        """
         config = MagicMock()
 
         service = module.SentinelOneExpectationService(config=config)
@@ -116,85 +159,164 @@ class TestSentinelOneExpectationService(unittest.TestCase):
         batch = [MagicMock()]
         end_date = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
         start_date = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
-        m_signature_extractor.extract_end_date.return_value = end_date
         m_signature_extractor.extract_start_date.return_value = start_date
 
         start, end = service._get_fetch_time_window(batch)
 
-        m_signature_extractor.extract_end_date.assert_called_once_with(batch)
+        m_signature_extractor.extract_end_date.assert_not_called()
         m_signature_extractor.extract_start_date.assert_called_once_with(batch)
         self.assertEqual(start, start_date)
-        self.assertEqual(end, end_date)
+        self.assertNotEqual(end, end_date)
+        self.assertLess(abs(end - datetime.now(timezone.utc)), timedelta(minutes=1))
 
     @patch.object(module, "SignatureExtractor")
     def test_get_fetch_time_window_without_start_date(self, m_signature_extractor, *_):
+        """Without a start date the threat window falls back to
+        now - SENTINELONE_TIME_WINDOW.
+
+        The window spans now - SENTINELONE_TIME_WINDOW to now.
+        """
         config = MagicMock()
 
         service = module.SentinelOneExpectationService(config=config)
         service.client_api.time_window = timedelta(hours=1)
 
         batch = [MagicMock()]
-        end_date = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-        m_signature_extractor.extract_end_date.return_value = end_date
         m_signature_extractor.extract_start_date.return_value = None
 
         start, end = service._get_fetch_time_window(batch)
 
-        self.assertEqual(start, end_date - timedelta(hours=1))
-        self.assertEqual(end, end_date)
+        m_signature_extractor.extract_end_date.assert_not_called()
+        self.assertEqual(start, end - timedelta(hours=1))
+        self.assertLess(abs(end - datetime.now(timezone.utc)), timedelta(minutes=1))
 
     @patch.object(module, "SignatureExtractor")
-    def test_get_fetch_time_window_with_start_date_after_end(
+    def test_get_fetch_time_window_with_start_date_in_future(
         self, m_signature_extractor, *_
     ):
+        """A start date in the future is anomalous; the window falls back
+        to now - SENTINELONE_TIME_WINDOW.
+
+        The window spans now - SENTINELONE_TIME_WINDOW to now.
+        """
         config = MagicMock()
 
         service = module.SentinelOneExpectationService(config=config)
         service.client_api.time_window = timedelta(hours=1)
 
         batch = [MagicMock()]
-        end_date = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
-        m_signature_extractor.extract_end_date.return_value = end_date
         m_signature_extractor.extract_start_date.return_value = datetime(
-            2024, 1, 2, 12, 0, 0, tzinfo=timezone.utc
+            2999, 1, 1, 12, 0, 0, tzinfo=timezone.utc
         )
 
         start, end = service._get_fetch_time_window(batch)
 
-        self.assertEqual(start, end_date - timedelta(hours=1))
-        self.assertEqual(end, end_date)
+        self.assertEqual(start, end - timedelta(hours=1))
+        self.assertLess(abs(end - datetime.now(timezone.utc)), timedelta(minutes=1))
 
-    def test_update_failures(self, *_):
+    def test_get_deep_visibility_fetch_window(self, *_):
+        """The DV event window ignores the signature dates and spans exactly
+        the configured lookback, ending at the reference time."""
         config = MagicMock()
 
         service = module.SentinelOneExpectationService(config=config)
+        service.client_api.deep_visibility_lookback = timedelta(hours=6)
+
+        now = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        start, end = service._get_deep_visibility_fetch_window(now=now)
+
+        self.assertEqual(end, now)
+        self.assertEqual(start, now - timedelta(hours=6))
+
+    def test_update_failures(self, *_):
+        """Valid results close the lifecycle; in-window failures stay held
+        pending; failures after the window are the final attempt (verdict)."""
+        config = MagicMock()
+
+        service = module.SentinelOneExpectationService(config=config)
+        service.retry_window = timedelta(minutes=10)
+
+        now = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
         uuid_zero = "6b7d53b5-2828-4be8-a797-a5193c615ec5"
         result_zero = MagicMock()
         result_zero.is_valid = True
         result_zero.expectation_id = uuid_zero
+        service.first_attempt_at[uuid_zero] = now - timedelta(minutes=2)
 
         uuid_one = "2930a07a-7077-478b-a7d0-27699a03edf3"
         result_one = MagicMock()
         result_one.is_valid = False
         result_one.expectation_id = uuid_one
-        service.failure_tracker[uuid_one] = 2
+        service.first_attempt_at[uuid_one] = now - timedelta(minutes=5)
 
         uuid_two = "adccb725-9769-4856-bbc3-1cdc1ff98a26"
         result_two = MagicMock()
         result_two.is_valid = False
         result_two.expectation_id = uuid_two
-        service.failure_tracker[uuid_two] = 5
+        service.first_attempt_at[uuid_two] = now - timedelta(minutes=15)
 
         m_results = [result_zero, result_one, result_two]
 
-        results = service._update_failures(m_results)
+        with patch.object(
+            module.SentinelOneExpectationService, "_now", return_value=now
+        ):
+            results = service._update_failures(m_results)
 
         self.assertNotEqual(len(m_results), len(results))
         self.assertEqual(len(results), 2)
-        self.assertEqual(service.failure_tracker[uuid_one], 3)
-        self.assertNotIn(uuid_two, service.failure_tracker)
-        self.assertNotIn(uuid_zero, service.failure_tracker)
+        self.assertIn(result_zero, results)
+        self.assertNotIn(result_one, results)
+        self.assertIn(result_two, results)
+        self.assertNotIn(uuid_zero, service.first_attempt_at)
+        self.assertIn(uuid_one, service.first_attempt_at)
+        self.assertNotIn(uuid_two, service.first_attempt_at)
+
+    def test_update_failures_first_attempt_opens_retry_window(self, *_):
+        """The first failed attempt opens the retry window anchored at that
+        moment and emits no verdict (re-fetched on the next cycle)."""
+        config = MagicMock()
+
+        service = module.SentinelOneExpectationService(config=config)
+        service.retry_window = timedelta(minutes=10)
+
+        now = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        uuid = "1e0f7b3c-5a2d-4f8e-9c1b-2d3e4f5a6b7c"
+        result = MagicMock()
+        result.is_valid = False
+        result.expectation_id = uuid
+
+        with patch.object(
+            module.SentinelOneExpectationService, "_now", return_value=now
+        ):
+            results = service._update_failures([result])
+
+        self.assertEqual(results, [])
+        self.assertIn(uuid, service.first_attempt_at)
+        self.assertEqual(service.first_attempt_at[uuid], now)
+
+    def test_update_failures_at_window_boundary_stays_pending(self, *_):
+        """An attempt at exactly retry_window since the first attempt is still
+        in-window (the boundary is inclusive); only the next cycle degrades."""
+        config = MagicMock()
+
+        service = module.SentinelOneExpectationService(config=config)
+        service.retry_window = timedelta(minutes=10)
+
+        now = datetime(2024, 1, 1, 12, 10, 0, tzinfo=timezone.utc)
+        uuid = "8c4a6d1e-3b7f-4e2a-8f0d-5c9e1b2a3d4f"
+        result = MagicMock()
+        result.is_valid = False
+        result.expectation_id = uuid
+        service.first_attempt_at[uuid] = now - timedelta(minutes=10)
+
+        with patch.object(
+            module.SentinelOneExpectationService, "_now", return_value=now
+        ):
+            results = service._update_failures([result])
+
+        self.assertEqual(results, [])
+        self.assertIn(uuid, service.first_attempt_at)
 
     def test_update_date_in_case_of_failures(self, *_):
         config = MagicMock()
@@ -202,7 +324,9 @@ class TestSentinelOneExpectationService(unittest.TestCase):
         service = module.SentinelOneExpectationService(config=config)
 
         uuid = UUID("feb4be6f-72c7-4212-8984-a7d7c42178f0")
-        service.failure_tracker[str(uuid)] = 1
+        service.first_attempt_at[str(uuid)] = datetime(
+            2026, 5, 4, 3, 0, 0, tzinfo=timezone.utc
+        )
 
         expectation = MagicMock()
         expectation.inject_expectation_id = uuid
@@ -216,7 +340,12 @@ class TestSentinelOneExpectationService(unittest.TestCase):
 
         batch = [expectation]
 
-        service._update_date_in_case_of_failures(batch)
+        with patch.object(
+            module.SentinelOneExpectationService,
+            "_now",
+            return_value=datetime(2026, 5, 4, 3, 5, 0, tzinfo=timezone.utc),
+        ):
+            service._update_date_in_case_of_failures(batch)
 
         self.assertNotEqual(signature.value, signature_value)
 

--- a/sentinelone/tests/unit/services/test_expectation_service.py
+++ b/sentinelone/tests/unit/services/test_expectation_service.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime, timedelta, timezone
 from unittest.mock import ANY, MagicMock, patch
 from uuid import UUID
 
@@ -104,6 +105,64 @@ class TestSentinelOneExpectationService(unittest.TestCase):
             [expectation_zero]
         )
         self.assertEqual(batches, [[expectation_zero]])
+
+    @patch.object(module, "SignatureExtractor")
+    def test_get_fetch_time_window_with_start_date(self, m_signature_extractor, *_):
+        config = MagicMock()
+
+        service = module.SentinelOneExpectationService(config=config)
+        service.client_api.time_window = timedelta(hours=1)
+
+        batch = [MagicMock()]
+        end_date = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        start_date = datetime(2024, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        m_signature_extractor.extract_end_date.return_value = end_date
+        m_signature_extractor.extract_start_date.return_value = start_date
+
+        start, end = service._get_fetch_time_window(batch)
+
+        m_signature_extractor.extract_end_date.assert_called_once_with(batch)
+        m_signature_extractor.extract_start_date.assert_called_once_with(batch)
+        self.assertEqual(start, start_date)
+        self.assertEqual(end, end_date)
+
+    @patch.object(module, "SignatureExtractor")
+    def test_get_fetch_time_window_without_start_date(self, m_signature_extractor, *_):
+        config = MagicMock()
+
+        service = module.SentinelOneExpectationService(config=config)
+        service.client_api.time_window = timedelta(hours=1)
+
+        batch = [MagicMock()]
+        end_date = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        m_signature_extractor.extract_end_date.return_value = end_date
+        m_signature_extractor.extract_start_date.return_value = None
+
+        start, end = service._get_fetch_time_window(batch)
+
+        self.assertEqual(start, end_date - timedelta(hours=1))
+        self.assertEqual(end, end_date)
+
+    @patch.object(module, "SignatureExtractor")
+    def test_get_fetch_time_window_with_start_date_after_end(
+        self, m_signature_extractor, *_
+    ):
+        config = MagicMock()
+
+        service = module.SentinelOneExpectationService(config=config)
+        service.client_api.time_window = timedelta(hours=1)
+
+        batch = [MagicMock()]
+        end_date = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        m_signature_extractor.extract_end_date.return_value = end_date
+        m_signature_extractor.extract_start_date.return_value = datetime(
+            2024, 1, 2, 12, 0, 0, tzinfo=timezone.utc
+        )
+
+        start, end = service._get_fetch_time_window(batch)
+
+        self.assertEqual(start, end_date - timedelta(hours=1))
+        self.assertEqual(end, end_date)
 
     def test_update_failures(self, *_):
         config = MagicMock()


### PR DESCRIPTION
## Proposed changes

Closes #490.

In OAEV, with the OAEV agent as executor and the S1 collector, expectations for
injected payloads (for example "In-Memory Mimikatz-DumpCreds" in Atomic Testing)
never got their update in the console, even though S1's own log showed the
detection. The verdict came back as Not Detected or Not Prevented. Three
separate gaps could each produce that result; this PR fixes all three.

**Deep-search backend (SaaS vs self-hosted).** On SaaS, deep-search now runs on
the SDL v2 query API, a new `FetcherSDL` that launches and polls an async query,
resumes via cursor, follows the forward-tag, and sends `Authorization: Bearer` as
the SDL v2 contract requires. Self-hosted instances keep the existing Deep
Visibility 1.0 fetcher. The instance type is detected automatically: the client
probes the MGMT account listing (`GET /web/api/v2.1/accounts`) once at init, an
`accountType` field means SaaS while its absence means self-hosted, and a failed
probe defaults to SaaS so a blip on a working account never flips it. The
service logs which backend it picked, once, at construction.

**Fetch windows.** The threat/alert window now ends at the current time and
starts from the `start_date` signature, or now minus `SENTINELONE_TIME_WINDOW`
when there is no start date. The signature end date no longer anchors or
truncates that window, so a fresh alert can no longer land outside the range
that gets fetched. The DV/SDL file-event window is a separate, fixed lookback,
`[now minus SENTINELONE_DEEP_VISIBILITY_LOOKBACK, now]` (new knob, default
`P1D`), independent of the signature dates because a file can be dropped or
executed long before the alert that references it. The threat-event fetcher
follows `nextCursor` to the end of the result set (defensive 200-page cap)
instead of reading only the first page, so a busy alert no longer has its file
events silently truncated.

**Transient failure handling.** A transient transport failure (a connection
drop, a timeout, a 408/429, a 5xx) no longer stamps a "Not Detected / Not
Prevented" verdict. The expectation is held pending: no verdict is emitted, it
stays unresolved in OAEV, and it is re-fetched on the next collector cycle, for
the length of a time-based `SENTINELONE_RETRY_WINDOW` (new knob, default
`PT10M`). The first attempt after that window has elapsed is the final one and
degrades to a negative verdict rather than staying open. That is the one-shot
blip from the issue, a single dropped connection being recorded as a verdict.
Permanent failures (validation, other 4xx) keep the immediate negative verdict.
On the transport side, every request the collector makes now carries an explicit
30 s timeout, and GET requests get a urllib3 `Retry` (429/5xx only, honors
`Retry-After`, backoff 0.5, at most 3 attempts).

## Implementation notes

- `is_self_hosted` is resolved on the client at construction. The expectation
  service picks `FetcherDeepVisibility` (DV 1.0) or `FetcherSDL` (SDL v2) once
  at init and logs the choice.
- The old count-based `failure_tracker` / `max_failure=5` retry is replaced by a
  time-based lifecycle keyed on `first_attempt_at`: the first failed attempt
  opens the window, attempts inside it are held, and the first attempt after it
  is emitted. A valid result closes it too. The clock goes through a single
  `_now()` seam.
- `_classify_error()` maps `SentinelOneNetworkError` to transient and
  `SentinelOneValidationError` to permanent, and reads `requests` `HTTPError`s
  by status: 408/429/5xx transient, other 4xx permanent, unknown transient. The
  fetchers re-raise already-classified errors unchanged so the status code is
  not buried in `__cause__` and misclassified as permanent.
- Pending results are dropped before batch results reach the daemon, so there is
  no daemon or manager contract change. The collector's `ExpectationResult`
  model gains an `is_pending` flag.
- Both new settings are ISO 8601 durations that flow from `SentinelOneConfigs`
  through `ConfigLoader.to_daemon_config()` to the client. Both are optional
  with safe defaults, so this PR changes no user-facing docs (the collector
  README config table lists only required fields).

## Testing

- 45 new tests on the branch: 3 for SaaS/self-hosted detection, 23 for the SDL v2
  fetcher (launch/poll shape, cursor resume, forward-tag, Bearer auth), 5 BDD
  tests for the transient lifecycle (no-verdict hold, plus degradation at 1-min,
  2-min, and 1-hour cadences), plus tests for the alert-versus-DV window
  decoupling, the pagination cap, and missing-signature-data not matching.
- `python -m pytest`: 88 passed.
- pre-commit (black / flake8 / isort / check-yaml): clean.

## Checklist

- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I added/updated tests
- [ ] I updated the documentation (n/a: no user-facing docs changed, both new
  settings are optional with safe defaults)
  
  ## Screenshot
  
<img width="2901" height="1425" alt="image" src="https://github.com/user-attachments/assets/2ed35c98-0eea-465d-b8bf-f951ce61cf6d" />
